### PR TITLE
Add Logger implementation

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,77 @@
+export enum LogLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+export interface Logger {
+    log(level: LogLevel, message: string): void;
+    log(level: LogLevel, tag: string, message: string): void;
+
+    print(message: string): void;
+    print(tag: string, message: string): void;
+
+    warning(message: string): void;
+    warning(tag: string, message: string): void;
+
+    error(message: string): void;
+    error(tag: string, message: string): void;
+}
+
+export abstract class AbstractLogger implements Logger {
+    abstract log(level: LogLevel, message: string): void;
+    abstract log(level: LogLevel, tag: string, message: string): void;
+
+    print(message: string): void;
+    print(tag: string, message: string): void;
+    print(tagOrMessage: string, message?: string): void {
+        if (message) {
+            this.log(LogLevel.Info, tagOrMessage, message);
+        } else {
+            this.log(LogLevel.Info, tagOrMessage);
+        }
+    }
+
+    warning(message: string): void;
+    warning(tag: string, message: string): void;
+    warning(tagOrMessage: string, message?: string): void {
+        if (message) {
+            this.log(LogLevel.Warning, tagOrMessage, message);
+        } else {
+            this.log(LogLevel.Warning, tagOrMessage);
+        }
+    }
+
+    error(message: string): void;
+    error(tag: string, message: string): void;
+    error(tagOrMessage: string, message?: string): void {
+        if (message) {
+            this.log(LogLevel.Error, tagOrMessage, message);
+        } else {
+            this.log(LogLevel.Error, tagOrMessage);
+        }
+    }
+}
+
+export class DeviceConsoleLogger extends AbstractLogger {
+    log(level: LogLevel, message: string): void;
+    log(level: LogLevel, tag: string, message: string): void;
+    log(level: LogLevel, tagOrMessage: string, message?: string): void {
+        if (message) {
+            message = `[${tagOrMessage}] ${message}`;
+        } else {
+            message = tagOrMessage;
+        }
+
+        switch (level) {
+            case LogLevel.Error:
+                return console.error(message);
+
+            case LogLevel.Warning:
+                return console.warn(message);
+
+            default:
+                return console.log(message);
+        }
+    }
+}

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,59 +1,100 @@
 export enum LogLevel {
+    Trace,
+    Debug,
     Info,
     Warning,
     Error,
+    Fatal,
+}
+
+export class UnknownLogLevelError extends Error {
+    constructor(message?: string) {
+        super(message);
+        this.name = "Unknown Log Level";
+    }
 }
 
 export interface Logger {
+    keyValue(key: string, value: any): void;
+
     log(level: LogLevel, message: string): void;
     log(level: LogLevel, tag: string, message: string): void;
 
-    print(message: string): void;
-    print(tag: string, message: string): void;
+    trace(message: string): void;
+    trace(tag: string, message: string): void;
+
+    debug(message: string): void;
+    debug(tag: string, message: string): void;
+
+    info(message: string): void;
+    info(tag: string, message: string): void;
 
     warning(message: string): void;
     warning(tag: string, message: string): void;
 
     error(message: string): void;
     error(tag: string, message: string): void;
+
+    fatal(message: string): void;
+    fatal(tag: string, message: string): void;
 }
 
 export abstract class AbstractLogger implements Logger {
+    abstract keyValue(key: string, value: any): void;
+
     abstract log(level: LogLevel, message: string): void;
     abstract log(level: LogLevel, tag: string, message: string): void;
 
-    print(message: string): void;
-    print(tag: string, message: string): void;
-    print(tagOrMessage: string, message?: string): void {
+    protected _log(level: LogLevel, tagOrMessage: string, message?: string): void {
         if (message) {
-            this.log(LogLevel.Info, tagOrMessage, message);
+            this.log(level, tagOrMessage, message);
         } else {
-            this.log(LogLevel.Info, tagOrMessage);
+            this.log(level, tagOrMessage);
         }
+    }
+
+    trace(message: string): void;
+    trace(tag: string, message: string): void;
+    trace(tagOrMessage: string, message?: string): void {
+        this._log(LogLevel.Trace, tagOrMessage, message);
+    }
+
+    debug(message: string): void;
+    debug(tag: string, message: string): void;
+    debug(tagOrMessage: string, message?: string): void {
+        this._log(LogLevel.Debug, tagOrMessage, message);
+    }
+
+    info(message: string): void;
+    info(tag: string, message: string): void;
+    info(tagOrMessage: string, message?: string): void {
+        this._log(LogLevel.Info, tagOrMessage, message);
     }
 
     warning(message: string): void;
     warning(tag: string, message: string): void;
     warning(tagOrMessage: string, message?: string): void {
-        if (message) {
-            this.log(LogLevel.Warning, tagOrMessage, message);
-        } else {
-            this.log(LogLevel.Warning, tagOrMessage);
-        }
+        this._log(LogLevel.Warning, tagOrMessage, message);
     }
 
     error(message: string): void;
     error(tag: string, message: string): void;
     error(tagOrMessage: string, message?: string): void {
-        if (message) {
-            this.log(LogLevel.Error, tagOrMessage, message);
-        } else {
-            this.log(LogLevel.Error, tagOrMessage);
-        }
+        this._log(LogLevel.Error, tagOrMessage, message);
+    }
+
+    fatal(message: string): void;
+    fatal(tag: string, message: string): void;
+    fatal(tagOrMessage: string, message?: string): void {
+        this._log(LogLevel.Fatal, tagOrMessage, message);
     }
 }
 
 export class DeviceConsoleLogger extends AbstractLogger {
+    keyValue(key: string, value: any): void {
+        this.info(`${key}=${value}`);
+    }
+
     log(level: LogLevel, message: string): void;
     log(level: LogLevel, tag: string, message: string): void;
     log(level: LogLevel, tagOrMessage: string, message?: string): void {
@@ -64,14 +105,24 @@ export class DeviceConsoleLogger extends AbstractLogger {
         }
 
         switch (level) {
+            case LogLevel.Fatal:
             case LogLevel.Error:
                 return console.error(message);
 
             case LogLevel.Warning:
                 return console.warn(message);
 
-            default:
+            case LogLevel.Info:
                 return console.log(message);
+
+            case LogLevel.Debug:
+                return console.debug(message);
+
+            case LogLevel.Trace:
+                return console.trace(message);
+
+            default:
+                throw new UnknownLogLevelError();
         }
     }
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -91,6 +91,13 @@ export abstract class AbstractLogger implements Logger {
 }
 
 export class DeviceConsoleLogger extends AbstractLogger {
+    protected logger: Console;
+
+    constructor(logger: Console) {
+        super();
+        this.logger = logger || console;
+    }
+
     keyValue(key: string, value: any): void {
         this.info(`${key}=${value}`);
     }
@@ -107,19 +114,19 @@ export class DeviceConsoleLogger extends AbstractLogger {
         switch (level) {
             case LogLevel.Fatal:
             case LogLevel.Error:
-                return console.error(message);
+                return this.logger.error(message);
 
             case LogLevel.Warning:
-                return console.warn(message);
+                return this.logger.warn(message);
 
             case LogLevel.Info:
-                return console.log(message);
+                return this.logger.log(message);
 
             case LogLevel.Debug:
-                return console.debug(message);
+                return this.logger.debug(message);
 
             case LogLevel.Trace:
-                return console.trace(message);
+                return this.logger.trace(message);
 
             default:
                 throw new UnknownLogLevelError();

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -93,7 +93,7 @@ export abstract class AbstractLogger implements Logger {
 export class DeviceConsoleLogger extends AbstractLogger {
     protected logger: Console;
 
-    constructor(logger: Console) {
+    constructor(logger?: Console) {
         super();
         this.logger = logger || console;
     }

--- a/packages/core/src/public-api.ts
+++ b/packages/core/src/public-api.ts
@@ -1,3 +1,4 @@
-export * from './repository';
 export * from './data';
 export * from './helpers';
+export * from './logger';
+export * from './repository';


### PR DESCRIPTION
I've implemented the Logger interface as per the reference and the discussions in mobilejazz/harmony-reference#14 and mobilejazz/harmony-reference#15.

I'm not sure if the file should go at root level and also if we should separate the interface/error/implementation into separate files.

Let me know your suggestions.