### PR TITLE
Use ES5 target instead of ES6 for maximum browser compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,12 +17,14 @@
         "allowJs": false,
         "strict": true,
         "strictNullChecks": false,
-        "target": "es2015",
+        "target": "es5",
         "lib": ["es2017", "dom"],
         "typeRoots": [
             "node_modules/@types"
         ]
     },
     "exclude": [
-        "./node_modules", "**/*.spec.ts"]
+        "./node_modules",
+        "**/*.spec.ts"
+    ]
 }


### PR DESCRIPTION
We need to use even older ES standard to be able to target old platforms.