### PR TITLE
Add `deleteAll` deprecation notices

### DIFF
--- a/packages/core/src/repository/cache.repository.ts
+++ b/packages/core/src/repository/cache.repository.ts
@@ -189,6 +189,9 @@ export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, D
     }
 
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
+        // tslint:disable-next-line:max-line-length
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+
         switch (operation.constructor) {
             case DefaultOperation:
                 return this.deleteAll(query, new MainSyncOperation());

--- a/packages/core/src/repository/cache.repository.ts
+++ b/packages/core/src/repository/cache.repository.ts
@@ -3,7 +3,7 @@ import {IdQuery, IdsQuery, Query} from './query/query';
 import {Operation, DefaultOperation} from './operation/operation';
 import {MethodNotImplementedError, NotFoundError, NotValidError, OperationNotSupportedError} from './errors';
 import {DeleteDataSource, GetDataSource, PutDataSource} from './data-source/data-source';
-import {Logger} from 'helpers';
+import {Logger, DeviceConsoleLogger} from 'helpers';
 
 export class MainOperation implements  Operation {}
 export class MainSyncOperation implements  Operation {}
@@ -44,7 +44,7 @@ export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, D
         private readonly putCache: PutDataSource<T>,
         private readonly deleteCache: DeleteDataSource,
         private readonly validator: ObjectValidator,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query, operation: Operation): Promise<T> {

--- a/packages/core/src/repository/cache.repository.ts
+++ b/packages/core/src/repository/cache.repository.ts
@@ -3,6 +3,7 @@ import {IdQuery, IdsQuery, Query} from './query/query';
 import {Operation, DefaultOperation} from './operation/operation';
 import {MethodNotImplementedError, NotFoundError, NotValidError, OperationNotSupportedError} from './errors';
 import {DeleteDataSource, GetDataSource, PutDataSource} from './data-source/data-source';
+import {Logger} from 'helpers';
 
 export class MainOperation implements  Operation {}
 export class MainSyncOperation implements  Operation {}
@@ -43,6 +44,7 @@ export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, D
         private readonly putCache: PutDataSource<T>,
         private readonly deleteCache: DeleteDataSource,
         private readonly validator: ObjectValidator,
+        private readonly logger: Logger,
     ) {}
 
     public async get(query: Query, operation: Operation): Promise<T> {
@@ -190,7 +192,7 @@ export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, D
 
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
         // tslint:disable-next-line:max-line-length
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
 
         switch (operation.constructor) {
             case DefaultOperation:

--- a/packages/core/src/repository/data-source/data-source-mapper.ts
+++ b/packages/core/src/repository/data-source/data-source-mapper.ts
@@ -1,5 +1,6 @@
 import { Mapper, Query } from '..';
 import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
+import { Logger } from 'helpers';
 
 /**
  * This data source uses mappers to map objects and redirects them to the contained data source, acting as a simple "translator".
@@ -18,6 +19,7 @@ export class DataSourceMapper<In, Out> implements GetDataSource<Out>, PutDataSou
         private readonly deleteDataSource: DeleteDataSource,
         private readonly toOutMapper: Mapper<In, Out>,
         private readonly toInMapper: Mapper<Out, In>,
+        private readonly logger: Logger,
     ) { }
 
     public async get(query: Query): Promise<Out> {
@@ -48,7 +50,7 @@ export class DataSourceMapper<In, Out> implements GetDataSource<Out>, PutDataSou
 
     public deleteAll(query: Query): Promise<void> {
         // tslint:disable-next-line:max-line-length
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.deleteDataSource.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/data-source-mapper.ts
+++ b/packages/core/src/repository/data-source/data-source-mapper.ts
@@ -47,7 +47,9 @@ export class DataSourceMapper<In, Out> implements GetDataSource<Out>, PutDataSou
     }
 
     public deleteAll(query: Query): Promise<void> {
-        return this.deleteDataSource.deleteAll(query);
+        // tslint:disable-next-line:max-line-length
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.deleteDataSource.delete(query);
     }
 }
 

--- a/packages/core/src/repository/data-source/data-source-mapper.ts
+++ b/packages/core/src/repository/data-source/data-source-mapper.ts
@@ -1,6 +1,6 @@
 import { Mapper, Query } from '..';
 import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
-import { Logger } from 'helpers';
+import { Logger, DeviceConsoleLogger } from 'helpers';
 
 /**
  * This data source uses mappers to map objects and redirects them to the contained data source, acting as a simple "translator".
@@ -19,7 +19,7 @@ export class DataSourceMapper<In, Out> implements GetDataSource<Out>, PutDataSou
         private readonly deleteDataSource: DeleteDataSource,
         private readonly toOutMapper: Mapper<In, Out>,
         private readonly toInMapper: Mapper<Out, In>,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) { }
 
     public async get(query: Query): Promise<Out> {

--- a/packages/core/src/repository/data-source/in-memory.data-source.ts
+++ b/packages/core/src/repository/data-source/in-memory.data-source.ts
@@ -1,8 +1,13 @@
 import {AllObjectsQuery, DeleteDataSource, GetDataSource, IdsQuery, KeyQuery, PutDataSource, Query, QueryNotSupportedError} from '..';
+import {Logger} from 'helpers';
 
 export class InMemoryDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
     private objects: any = {};
     private arrays: any = {};
+
+    constructor(
+        private readonly logger: Logger,
+    ) {}
 
     public async get(query: Query): Promise<T> {
         if (query instanceof KeyQuery) {
@@ -80,7 +85,7 @@ export class InMemoryDataSource<T> implements GetDataSource<T>, PutDataSource<T>
 
     public async deleteAll(query: Query): Promise<void> {
         // tslint:disable-next-line:max-line-length
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead. Rewrite using `delete` with `AllObjectsQuery` to remove all entries or with any other `Query` to remove one or more entries.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead. Rewrite using `delete` with `AllObjectsQuery` to remove all entries or with any other `Query` to remove one or more entries.');
         return this.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/in-memory.data-source.ts
+++ b/packages/core/src/repository/data-source/in-memory.data-source.ts
@@ -1,12 +1,12 @@
 import {AllObjectsQuery, DeleteDataSource, GetDataSource, IdsQuery, KeyQuery, PutDataSource, Query, QueryNotSupportedError} from '..';
-import {Logger} from 'helpers';
+import {Logger, DeviceConsoleLogger} from 'helpers';
 
 export class InMemoryDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
     private objects: any = {};
     private arrays: any = {};
 
     constructor(
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query): Promise<T> {

--- a/packages/core/src/repository/data-source/in-memory.data-source.ts
+++ b/packages/core/src/repository/data-source/in-memory.data-source.ts
@@ -63,28 +63,24 @@ export class InMemoryDataSource<T> implements GetDataSource<T>, PutDataSource<T>
 
     public async delete(query: Query): Promise<void> {
         if (query instanceof KeyQuery) {
+            delete this.arrays[query.key];
             delete this.objects[query.key];
-            return;
+        } else if (query instanceof IdsQuery) {
+            for (let key of query.ids) {
+                delete this.arrays[key];
+                delete this.objects[key];
+            }
+        } else if (query instanceof AllObjectsQuery) {
+            this.arrays = {};
+            this.objects = {};
         } else {
             throw new QueryNotSupportedError();
         }
     }
 
     public async deleteAll(query: Query): Promise<void> {
-        if (query instanceof KeyQuery) {
-            delete this.arrays[query.key];
-            return;
-        } else if (query instanceof IdsQuery) {
-            for (let key of query.ids) {
-                delete this.objects[key];
-            }
-            return;
-        } else if (query instanceof AllObjectsQuery) {
-            this.objects = {};
-            this.arrays = {};
-            return;
-        } else {
-            throw new QueryNotSupportedError();
-        }
+        // tslint:disable-next-line:max-line-length
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead. Rewrite using `delete` with `AllObjectsQuery` to remove all entries or with any other `Query` to remove one or more entries.');
+        return this.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/local-storage.data-source.ts
+++ b/packages/core/src/repository/data-source/local-storage.data-source.ts
@@ -42,10 +42,16 @@ export class LocalStorageDataSource  implements GetDataSource<string>, PutDataSo
 
     public async delete(query: Query): Promise<void> {
         if (query instanceof KeyQuery) {
-            localStorage.removeItem(query.key);
-            if (localStorage.getItem(query.key) !== null) {
+            let keys = query.key.split(',');
+            let result = keys.map(key => {
+                localStorage.removeItem(key);
+                return localStorage.getItem(key) === null;
+            });
+
+            if (result.indexOf(false) !== -1) {
                 throw new DeleteError();
             }
+
             return;
         } else {
             throw QueryNotSupportedError;
@@ -53,18 +59,8 @@ export class LocalStorageDataSource  implements GetDataSource<string>, PutDataSo
     }
 
     public async deleteAll(query: Query): Promise<void> {
-        if (query instanceof KeyQuery) {
-            let keys = query.key.split(',');
-            let result = keys.map((key: string) => {
-                localStorage.removeItem(key);
-                return localStorage.getItem(key) === null;
-            });
-            if (result.indexOf(false) !== -1) {
-                throw new DeleteError();
-            }
-            return;
-        } else {
-            throw QueryNotSupportedError;
-        }
+        // tslint:disable-next-line:max-line-length
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/local-storage.data-source.ts
+++ b/packages/core/src/repository/data-source/local-storage.data-source.ts
@@ -1,10 +1,10 @@
 import { DeleteError, KeyQuery, Query, QueryNotSupportedError } from '..';
 import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
-import { Logger } from 'helpers';
+import { Logger, DeviceConsoleLogger } from 'helpers';
 
 export class LocalStorageDataSource  implements GetDataSource<string>, PutDataSource<string>, DeleteDataSource {
     constructor(
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query): Promise<string> {

--- a/packages/core/src/repository/data-source/local-storage.data-source.ts
+++ b/packages/core/src/repository/data-source/local-storage.data-source.ts
@@ -1,7 +1,12 @@
 import { DeleteError, KeyQuery, Query, QueryNotSupportedError } from '..';
 import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
+import { Logger } from 'helpers';
 
 export class LocalStorageDataSource  implements GetDataSource<string>, PutDataSource<string>, DeleteDataSource {
+    constructor(
+        private readonly logger: Logger,
+    ) {}
+
     public async get(query: Query): Promise<string> {
         if (query instanceof KeyQuery) {
             return localStorage.getItem(query.key) as string;
@@ -60,7 +65,7 @@ export class LocalStorageDataSource  implements GetDataSource<string>, PutDataSo
 
     public async deleteAll(query: Query): Promise<void> {
         // tslint:disable-next-line:max-line-length
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/mock.data-source.ts
+++ b/packages/core/src/repository/data-source/mock.data-source.ts
@@ -28,6 +28,6 @@ export class MockDataSource<T> implements  GetDataSource<T>, PutDataSource<T>, D
     }
 
     public async deleteAll(query: Query): Promise<void> {
-        return;
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
     }
 }

--- a/packages/core/src/repository/data-source/mock.data-source.ts
+++ b/packages/core/src/repository/data-source/mock.data-source.ts
@@ -1,10 +1,12 @@
 import {DeleteDataSource, GetDataSource, PutDataSource} from './data-source';
 import {Query} from '..';
+import {Logger} from 'helpers';
 
 export class MockDataSource<T> implements  GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
     constructor(
         private readonly one: T,
         private readonly many: T[],
+        private readonly logger: Logger,
     ) {}
 
     public async get(query: Query): Promise<T> {
@@ -28,6 +30,6 @@ export class MockDataSource<T> implements  GetDataSource<T>, PutDataSource<T>, D
     }
 
     public async deleteAll(query: Query): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
     }
 }

--- a/packages/core/src/repository/data-source/mock.data-source.ts
+++ b/packages/core/src/repository/data-source/mock.data-source.ts
@@ -1,12 +1,12 @@
 import {DeleteDataSource, GetDataSource, PutDataSource} from './data-source';
 import {Query} from '..';
-import {Logger} from 'helpers';
+import {Logger, DeviceConsoleLogger} from 'helpers';
 
 export class MockDataSource<T> implements  GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
     constructor(
         private readonly one: T,
         private readonly many: T[],
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query): Promise<T> {

--- a/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
@@ -27,6 +27,7 @@ import {
     SQLWherePaginationQuery,
     SQLWhereQuery,
 } from "./sql.query";
+import { Logger } from "helpers";
 
 export type RawSQLData = any;
 
@@ -55,6 +56,7 @@ export class RawSQLDataSource implements GetDataSource<RawSQLData>, PutDataSourc
         protected readonly sqlInterface: SQLInterface,
         protected readonly tableName: string,
         protected readonly columns: string[],
+        protected readonly logger: Logger,
         protected readonly idColumn = BaseColumnId,
         protected readonly createdAtColumn = BaseColumnCreatedAt,
         protected readonly updatedAtColumn = BaseColumnUpdatedAt,
@@ -294,7 +296,7 @@ export class RawSQLDataSource implements GetDataSource<RawSQLData>, PutDataSourc
 
     async deleteAll(query: Query): Promise<void> {
         // tslint:disable-next-line:max-line-length
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
@@ -27,7 +27,7 @@ import {
     SQLWherePaginationQuery,
     SQLWhereQuery,
 } from "./sql.query";
-import { Logger } from "helpers";
+import { Logger, DeviceConsoleLogger } from "helpers";
 
 export type RawSQLData = any;
 
@@ -56,10 +56,10 @@ export class RawSQLDataSource implements GetDataSource<RawSQLData>, PutDataSourc
         protected readonly sqlInterface: SQLInterface,
         protected readonly tableName: string,
         protected readonly columns: string[],
-        protected readonly logger: Logger,
         protected readonly idColumn = BaseColumnId,
         protected readonly createdAtColumn = BaseColumnCreatedAt,
         protected readonly updatedAtColumn = BaseColumnUpdatedAt,
+        protected readonly logger: Logger = new DeviceConsoleLogger(),
     ) {
         let tableColumns = [];
         if (createdAtColumn) {

--- a/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
@@ -275,12 +275,7 @@ export class RawSQLDataSource implements GetDataSource<RawSQLData>, PutDataSourc
                 .query(`delete from ${this.sqlDialect.getTableName(this.tableName)} where ${this.idColumn} = ${this.sqlDialect.getParameterSymbol(1)}`, [query.id])
                 .then(() => Promise.resolve())
                 .catch(e => { throw this.sqlDialect.mapError(e); });
-        }
-        throw new QueryNotSupportedError();
-    }
-
-    async deleteAll(query: Query): Promise<void> {
-        if (query instanceof IdsQuery) {
+        } else if (query instanceof IdsQuery) {
             return this.sqlInterface
                 // tslint:disable-next-line:max-line-length
                 .query(`delete from ${this.sqlDialect.getTableName(this.tableName)} where ${this.idColumn} in (${this.inStatement(query.ids.length)})`, query.ids)
@@ -293,6 +288,13 @@ export class RawSQLDataSource implements GetDataSource<RawSQLData>, PutDataSourc
                 .then(() => Promise.resolve())
                 .catch(e => { throw this.sqlDialect.mapError(e); });
         }
+
         throw new QueryNotSupportedError();
+    }
+
+    async deleteAll(query: Query): Promise<void> {
+        // tslint:disable-next-line:max-line-length
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.delete(query);
     }
 }

--- a/packages/core/src/repository/data-source/void.data-source.ts
+++ b/packages/core/src/repository/data-source/void.data-source.ts
@@ -1,10 +1,10 @@
 import {DeleteDataSource, GetDataSource, PutDataSource} from './data-source';
 import {MethodNotImplementedError, Query} from '..';
-import {Logger} from 'helpers';
+import {Logger, DeviceConsoleLogger} from 'helpers';
 
 export class VoidDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
     constructor(
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query): Promise<T> {
@@ -55,7 +55,7 @@ export class VoidPutDataSource<T> implements PutDataSource<T> {
 
 export class VoidDeleteDataSource implements DeleteDataSource {
     constructor(
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async delete(query: Query): Promise<void> {

--- a/packages/core/src/repository/data-source/void.data-source.ts
+++ b/packages/core/src/repository/data-source/void.data-source.ts
@@ -1,7 +1,12 @@
 import {DeleteDataSource, GetDataSource, PutDataSource} from './data-source';
 import {MethodNotImplementedError, Query} from '..';
+import {Logger} from 'helpers';
 
 export class VoidDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
+    constructor(
+        private readonly logger: Logger,
+    ) {}
+
     public async get(query: Query): Promise<T> {
         throw new MethodNotImplementedError('Called get on VoidDataSource');
     }
@@ -23,7 +28,7 @@ export class VoidDataSource<T> implements GetDataSource<T>, PutDataSource<T>, De
     }
 
     public async deleteAll(query: Query): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated.');
         throw new MethodNotImplementedError('Called deleteAll on VoidDataSource');
     }
 }
@@ -49,12 +54,16 @@ export class VoidPutDataSource<T> implements PutDataSource<T> {
 }
 
 export class VoidDeleteDataSource implements DeleteDataSource {
+    constructor(
+        private readonly logger: Logger,
+    ) {}
+
     public async delete(query: Query): Promise<void> {
         throw new MethodNotImplementedError('Called delete on VoidDeleteDataSource');
     }
 
     public async deleteAll(query: Query): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated.');
         throw new MethodNotImplementedError('Called deleteAll on VoidDeleteDataSource');
     }
 }

--- a/packages/core/src/repository/data-source/void.data-source.ts
+++ b/packages/core/src/repository/data-source/void.data-source.ts
@@ -23,6 +23,7 @@ export class VoidDataSource<T> implements GetDataSource<T>, PutDataSource<T>, De
     }
 
     public async deleteAll(query: Query): Promise<void> {
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated.');
         throw new MethodNotImplementedError('Called deleteAll on VoidDataSource');
     }
 }
@@ -53,6 +54,7 @@ export class VoidDeleteDataSource implements DeleteDataSource {
     }
 
     public async deleteAll(query: Query): Promise<void> {
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated.');
         throw new MethodNotImplementedError('Called deleteAll on VoidDeleteDataSource');
     }
 }

--- a/packages/core/src/repository/interactor/delete-all.interactor.ts
+++ b/packages/core/src/repository/interactor/delete-all.interactor.ts
@@ -1,11 +1,14 @@
 import { DefaultOperation, DeleteRepository, Operation, Query, VoidQuery } from '../index';
+import { Logger } from 'helpers';
 
 export class DeleteAllInteractor {
-
-    constructor(private readonly repository: DeleteRepository) {}
+    constructor(
+        private readonly repository: DeleteRepository,
+        private readonly logger: Logger,
+    ) {}
 
     public execute(query: Query = new VoidQuery(), operation: Operation = new DefaultOperation()): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `DeleteInteractor` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `DeleteInteractor` instead.');
         return this.repository.deleteAll(query, operation);
     }
 }

--- a/packages/core/src/repository/interactor/delete-all.interactor.ts
+++ b/packages/core/src/repository/interactor/delete-all.interactor.ts
@@ -5,6 +5,7 @@ export class DeleteAllInteractor {
     constructor(private readonly repository: DeleteRepository) {}
 
     public execute(query: Query = new VoidQuery(), operation: Operation = new DefaultOperation()): Promise<void> {
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `DeleteInteractor` instead.');
         return this.repository.deleteAll(query, operation);
     }
 }

--- a/packages/core/src/repository/interactor/delete-all.interactor.ts
+++ b/packages/core/src/repository/interactor/delete-all.interactor.ts
@@ -1,10 +1,10 @@
 import { DefaultOperation, DeleteRepository, Operation, Query, VoidQuery } from '../index';
-import { Logger } from 'helpers';
+import { Logger, DeviceConsoleLogger } from 'helpers';
 
 export class DeleteAllInteractor {
     constructor(
         private readonly repository: DeleteRepository,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public execute(query: Query = new VoidQuery(), operation: Operation = new DefaultOperation()): Promise<void> {

--- a/packages/core/src/repository/repository-mapper.ts
+++ b/packages/core/src/repository/repository-mapper.ts
@@ -2,6 +2,7 @@ import { Mapper } from './mapper/mapper';
 import { DefaultOperation, Operation } from './operation/operation';
 import { Query } from './query/query';
 import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { Logger } from 'helpers';
 
 /**
  * This repository uses mappers to map objects and redirects them to the contained repository, acting as a simple "translator".
@@ -20,6 +21,7 @@ export class RepositoryMapper<In, Out> implements GetRepository<Out>, PutReposit
         private readonly deleteRepository: DeleteRepository,
         private readonly toOutMapper: Mapper<In, Out>,
         private readonly toInMapper: Mapper<Out, In>,
+        private readonly logger: Logger,
     ) {}
 
     public async get(query: Query, operation: Operation): Promise<Out> {
@@ -49,7 +51,7 @@ export class RepositoryMapper<In, Out> implements GetRepository<Out>, PutReposit
     }
 
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.deleteRepository.delete(query, operation);
     }
 

--- a/packages/core/src/repository/repository-mapper.ts
+++ b/packages/core/src/repository/repository-mapper.ts
@@ -2,7 +2,7 @@ import { Mapper } from './mapper/mapper';
 import { DefaultOperation, Operation } from './operation/operation';
 import { Query } from './query/query';
 import { DeleteRepository, GetRepository, PutRepository } from './repository';
-import { Logger } from 'helpers';
+import { Logger, DeviceConsoleLogger } from 'helpers';
 
 /**
  * This repository uses mappers to map objects and redirects them to the contained repository, acting as a simple "translator".
@@ -21,7 +21,7 @@ export class RepositoryMapper<In, Out> implements GetRepository<Out>, PutReposit
         private readonly deleteRepository: DeleteRepository,
         private readonly toOutMapper: Mapper<In, Out>,
         private readonly toInMapper: Mapper<Out, In>,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query, operation: Operation): Promise<Out> {

--- a/packages/core/src/repository/repository-mapper.ts
+++ b/packages/core/src/repository/repository-mapper.ts
@@ -49,7 +49,8 @@ export class RepositoryMapper<In, Out> implements GetRepository<Out>, PutReposit
     }
 
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
-        return this.deleteRepository.deleteAll(query, operation);
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.deleteRepository.delete(query, operation);
     }
 
 }

--- a/packages/core/src/repository/single-data-source.repository.ts
+++ b/packages/core/src/repository/single-data-source.repository.ts
@@ -2,6 +2,7 @@ import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source/da
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
 import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { Logger } from 'helpers';
 
 export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
 
@@ -9,6 +10,7 @@ export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepos
         private readonly getDataSource: GetDataSource<T>,
         private readonly putDataSource: PutDataSource<T>,
         private readonly deleteDataSource: DeleteDataSource,
+        private readonly logger: Logger,
     ) {}
 
     public get(query: Query, operation: Operation): Promise<T> {
@@ -32,7 +34,7 @@ export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepos
     }
 
     public deleteAll(query: Query, operation: Operation): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.deleteDataSource.delete(query);
     }
 
@@ -71,9 +73,9 @@ export class SinglePutDataSourceRepository<T> implements PutRepository<T> {
 }
 
 export class SingleDeleteDataSourceRepository implements DeleteRepository {
-
     constructor(
         private readonly deleteDataSource: DeleteDataSource,
+        private readonly logger: Logger,
     ) {}
 
     public delete(query: Query, operation: Operation): Promise<void> {
@@ -81,7 +83,7 @@ export class SingleDeleteDataSourceRepository implements DeleteRepository {
     }
 
     public deleteAll(query: Query, operation: Operation): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.deleteDataSource.delete(query);
     }
 }

--- a/packages/core/src/repository/single-data-source.repository.ts
+++ b/packages/core/src/repository/single-data-source.repository.ts
@@ -32,7 +32,8 @@ export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepos
     }
 
     public deleteAll(query: Query, operation: Operation): Promise<void> {
-        return this.deleteDataSource.deleteAll(query);
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.deleteDataSource.delete(query);
     }
 
 }
@@ -80,6 +81,7 @@ export class SingleDeleteDataSourceRepository implements DeleteRepository {
     }
 
     public deleteAll(query: Query, operation: Operation): Promise<void> {
-        return this.deleteDataSource.deleteAll(query);
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.deleteDataSource.delete(query);
     }
 }

--- a/packages/core/src/repository/single-data-source.repository.ts
+++ b/packages/core/src/repository/single-data-source.repository.ts
@@ -2,7 +2,7 @@ import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source/da
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
 import { DeleteRepository, GetRepository, PutRepository } from './repository';
-import { Logger } from 'helpers';
+import { Logger, DeviceConsoleLogger } from 'helpers';
 
 export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
 
@@ -10,7 +10,7 @@ export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepos
         private readonly getDataSource: GetDataSource<T>,
         private readonly putDataSource: PutDataSource<T>,
         private readonly deleteDataSource: DeleteDataSource,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public get(query: Query, operation: Operation): Promise<T> {
@@ -75,7 +75,7 @@ export class SinglePutDataSourceRepository<T> implements PutRepository<T> {
 export class SingleDeleteDataSourceRepository implements DeleteRepository {
     constructor(
         private readonly deleteDataSource: DeleteDataSource,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public delete(query: Query, operation: Operation): Promise<void> {

--- a/packages/core/src/repository/void.repository.ts
+++ b/packages/core/src/repository/void.repository.ts
@@ -20,6 +20,7 @@ export class VoidRepository<T> implements GetRepository<T>, PutRepository<T>, De
         throw new MethodNotImplementedError('Called delete on VoidRepository');
     }
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         throw new MethodNotImplementedError('Called deleteAll on VoidRepository');
     }
 }
@@ -47,6 +48,7 @@ export class VoidDeleteRepository implements DeleteRepository {
         throw new MethodNotImplementedError('Called delete on VoidDeleteRepository');
     }
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         throw new MethodNotImplementedError('Called deleteAll on VoidDeleteRepository');
     }
 }

--- a/packages/core/src/repository/void.repository.ts
+++ b/packages/core/src/repository/void.repository.ts
@@ -2,8 +2,13 @@ import { MethodNotImplementedError } from './errors';
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
 import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { Logger } from 'helpers';
 
 export class VoidRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
+    constructor(
+        private readonly logger: Logger,
+    ) {}
+
     public async get(query: Query, operation: Operation): Promise<T> {
         throw new MethodNotImplementedError('Called get on VoidRepository');
     }
@@ -20,7 +25,7 @@ export class VoidRepository<T> implements GetRepository<T>, PutRepository<T>, De
         throw new MethodNotImplementedError('Called delete on VoidRepository');
     }
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         throw new MethodNotImplementedError('Called deleteAll on VoidRepository');
     }
 }
@@ -44,11 +49,16 @@ export class VoidPutRepository<T> implements PutRepository<T> {
 }
 
 export class VoidDeleteRepository implements DeleteRepository {
+    constructor(
+        private readonly logger: Logger,
+    ) {}
+
     public async delete(query: Query, operation: Operation): Promise<void> {
         throw new MethodNotImplementedError('Called delete on VoidDeleteRepository');
     }
+
     public async deleteAll(query: Query, operation: Operation): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         throw new MethodNotImplementedError('Called deleteAll on VoidDeleteRepository');
     }
 }

--- a/packages/core/src/repository/void.repository.ts
+++ b/packages/core/src/repository/void.repository.ts
@@ -2,11 +2,11 @@ import { MethodNotImplementedError } from './errors';
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
 import { DeleteRepository, GetRepository, PutRepository } from './repository';
-import { Logger } from 'helpers';
+import { Logger, DeviceConsoleLogger } from 'helpers';
 
 export class VoidRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
     constructor(
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async get(query: Query, operation: Operation): Promise<T> {
@@ -50,7 +50,7 @@ export class VoidPutRepository<T> implements PutRepository<T> {
 
 export class VoidDeleteRepository implements DeleteRepository {
     constructor(
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     public async delete(query: Query, operation: Operation): Promise<void> {

--- a/packages/nest/src/oauth/data/repository/oauth-client.repository.ts
+++ b/packages/nest/src/oauth/data/repository/oauth-client.repository.ts
@@ -73,6 +73,7 @@ export class OAuthClientRepository implements GetRepository<OAuthClientModel>, P
         let grants: string[];
         if (value.grants !== undefined) {
             // Deleting all grants
+            console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
             await this.deleteClientGrantsDataSource.deleteAll(new OAuthClientIdQuery(client.id));
             // Adding new grants
             grants = await this.putClientGrantsDataSource
@@ -101,6 +102,7 @@ export class OAuthClientRepository implements GetRepository<OAuthClientModel>, P
     }
 
     deleteAll(query: Query, operation: Operation): Promise<void> {
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         // client grants will be deleted as table column is configured on delete cascade.
         return undefined;
     }

--- a/packages/nest/src/oauth/data/repository/oauth-client.repository.ts
+++ b/packages/nest/src/oauth/data/repository/oauth-client.repository.ts
@@ -3,11 +3,13 @@ import {
     DeleteRepository,
     GetDataSource,
     GetRepository,
-    IdQuery, MethodNotImplementedError,
+    MethodNotImplementedError,
     Operation,
     PutDataSource,
     PutRepository,
-    Query, QueryNotSupportedError, VoidQuery,
+    Query,
+    VoidQuery,
+    Logger,
 } from '@mobilejazz/harmony-core';
 import {OAuthClientModel} from '../../domain/oauth-client.model';
 import {OAuthClientEntity} from '../entity/oauth-client.entity';
@@ -22,6 +24,7 @@ export class OAuthClientRepository implements GetRepository<OAuthClientModel>, P
         private readonly getClientGrantsDataSource: GetDataSource<OAuthClientGrantEntity>,
         private readonly putClientGrantsDataSource: PutDataSource<OAuthClientGrantEntity>,
         private readonly deleteClientGrantsDataSource: DeleteDataSource,
+        private readonly logger: Logger,
     ) {}
 
     async get(query: Query, operation: Operation): Promise<OAuthClientModel> {
@@ -73,7 +76,7 @@ export class OAuthClientRepository implements GetRepository<OAuthClientModel>, P
         let grants: string[];
         if (value.grants !== undefined) {
             // Deleting all grants
-            console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+            this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
             await this.deleteClientGrantsDataSource.deleteAll(new OAuthClientIdQuery(client.id));
             // Adding new grants
             grants = await this.putClientGrantsDataSource
@@ -102,7 +105,7 @@ export class OAuthClientRepository implements GetRepository<OAuthClientModel>, P
     }
 
     deleteAll(query: Query, operation: Operation): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         // client grants will be deleted as table column is configured on delete cascade.
         return undefined;
     }

--- a/packages/nest/src/oauth/data/repository/oauth-client.repository.ts
+++ b/packages/nest/src/oauth/data/repository/oauth-client.repository.ts
@@ -10,6 +10,7 @@ import {
     Query,
     VoidQuery,
     Logger,
+    DeviceConsoleLogger,
 } from '@mobilejazz/harmony-core';
 import {OAuthClientModel} from '../../domain/oauth-client.model';
 import {OAuthClientEntity} from '../entity/oauth-client.entity';
@@ -24,7 +25,7 @@ export class OAuthClientRepository implements GetRepository<OAuthClientModel>, P
         private readonly getClientGrantsDataSource: GetDataSource<OAuthClientGrantEntity>,
         private readonly putClientGrantsDataSource: PutDataSource<OAuthClientGrantEntity>,
         private readonly deleteClientGrantsDataSource: DeleteDataSource,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     async get(query: Query, operation: Operation): Promise<OAuthClientModel> {

--- a/packages/nest/src/oauth/data/repository/oauth-token.repository.ts
+++ b/packages/nest/src/oauth/data/repository/oauth-token.repository.ts
@@ -66,6 +66,7 @@ export class OAuthTokenRepository implements GetRepository<OAuthTokenModel>, Put
         let scope: string[];
         if (value.scope !== undefined && value.scope !== null && value.scope.length > 0) {
             // Deleting all grants
+            console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
             await this.deleteTokenScopeDataSource.deleteAll(new OAuthTokenIdQuery(token.id));
             // Adding new grants
             scope = await this.putTokenScopeDataSource
@@ -96,6 +97,7 @@ export class OAuthTokenRepository implements GetRepository<OAuthTokenModel>, Put
 
     async deleteAll(query: Query, operation: Operation): Promise<void> {
         // token scopes will be deleted as table column is configured on delete cascade.
-        return this.deleteTokenDataSource.deleteAll(query);
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        return this.deleteTokenDataSource.delete(query);
     }
 }

--- a/packages/nest/src/oauth/data/repository/oauth-token.repository.ts
+++ b/packages/nest/src/oauth/data/repository/oauth-token.repository.ts
@@ -2,11 +2,16 @@ import {
     DeleteDataSource,
     DeleteRepository,
     GetDataSource,
-    GetRepository, IdQuery, InvalidArgumentError, MethodNotImplementedError,
+    GetRepository,
+    IdQuery,
+    InvalidArgumentError,
+    MethodNotImplementedError,
     Operation,
     PutDataSource,
     PutRepository,
-    Query, VoidQuery,
+    Query,
+    VoidQuery,
+    Logger,
 } from '@mobilejazz/harmony-core';
 import {OAuthTokenModel} from '../../domain/oauth-token.model';
 import {OAuthClientModel} from '../../domain/oauth-client.model';
@@ -24,6 +29,7 @@ export class OAuthTokenRepository implements GetRepository<OAuthTokenModel>, Put
         private readonly getTokenScopeDataSource: GetDataSource<OAuthTokenScopeEntity>,
         private readonly putTokenScopeDataSource: PutDataSource<OAuthTokenScopeEntity>,
         private readonly deleteTokenScopeDataSource: DeleteDataSource,
+        private readonly logger: Logger,
     ) {}
 
     async get(query: Query, operation: Operation): Promise<OAuthTokenModel> {
@@ -66,7 +72,7 @@ export class OAuthTokenRepository implements GetRepository<OAuthTokenModel>, Put
         let scope: string[];
         if (value.scope !== undefined && value.scope !== null && value.scope.length > 0) {
             // Deleting all grants
-            console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+            this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
             await this.deleteTokenScopeDataSource.deleteAll(new OAuthTokenIdQuery(token.id));
             // Adding new grants
             scope = await this.putTokenScopeDataSource
@@ -97,7 +103,7 @@ export class OAuthTokenRepository implements GetRepository<OAuthTokenModel>, Put
 
     async deleteAll(query: Query, operation: Operation): Promise<void> {
         // token scopes will be deleted as table column is configured on delete cascade.
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Use `delete` instead.');
         return this.deleteTokenDataSource.delete(query);
     }
 }

--- a/packages/nest/src/oauth/data/repository/oauth-token.repository.ts
+++ b/packages/nest/src/oauth/data/repository/oauth-token.repository.ts
@@ -12,6 +12,7 @@ import {
     Query,
     VoidQuery,
     Logger,
+    DeviceConsoleLogger,
 } from '@mobilejazz/harmony-core';
 import {OAuthTokenModel} from '../../domain/oauth-token.model';
 import {OAuthClientModel} from '../../domain/oauth-client.model';
@@ -29,7 +30,7 @@ export class OAuthTokenRepository implements GetRepository<OAuthTokenModel>, Put
         private readonly getTokenScopeDataSource: GetDataSource<OAuthTokenScopeEntity>,
         private readonly putTokenScopeDataSource: PutDataSource<OAuthTokenScopeEntity>,
         private readonly deleteTokenScopeDataSource: DeleteDataSource,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     async get(query: Query, operation: Operation): Promise<OAuthTokenModel> {

--- a/packages/typeorm/src/typeorm.data-source.ts
+++ b/packages/typeorm/src/typeorm.data-source.ts
@@ -9,12 +9,17 @@ import {
     Query,
     QueryNotSupportedError,
     VoidQuery,
-    DeleteError, NotFoundError,
+    DeleteError,
+    NotFoundError,
+    Logger,
 } from '@mobilejazz/harmony-core';
 import { Repository as TypeORMRepository, In, Condition } from 'typeorm';
 
 export class TypeOrmDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
-    constructor(private readonly repository: TypeORMRepository<T>) {}
+    constructor(
+        private readonly repository: TypeORMRepository<T>,
+        private readonly logger: Logger,
+    ) {}
 
     async get(query: Query): Promise<T> {
         if (query instanceof IdQuery) {
@@ -99,7 +104,7 @@ export class TypeOrmDataSource<T> implements GetDataSource<T>, PutDataSource<T>,
     }
 
     async deleteAll(query: Query): Promise<void> {
-        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        this.logger.warning('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
         return this.delete(query);
     }
 

--- a/packages/typeorm/src/typeorm.data-source.ts
+++ b/packages/typeorm/src/typeorm.data-source.ts
@@ -90,18 +90,17 @@ export class TypeOrmDataSource<T> implements GetDataSource<T>, PutDataSource<T>,
         if (query instanceof IdQuery) {
             const entity = await this.repository.findOne(query.id);
             return this.remove(entity);
+        } else if (query instanceof IdsQuery) {
+            const entities = await this.findAllEntitiesByIds(query.ids);
+            return this.remove(entities);
         } else {
             throw new QueryNotSupportedError();
         }
     }
 
     async deleteAll(query: Query): Promise<void> {
-        if (query instanceof IdsQuery) {
-            const entities = await this.findAllEntitiesByIds(query.ids);
-            return this.remove(entities);
-        } else {
-            throw new QueryNotSupportedError();
-        }
+        console.warn('[DEPRECATION] `deleteAll` will be deprecated. Calling `delete` instead.');
+        return this.delete(query);
     }
 
     private buildArrayQuery(conditions: any): any {

--- a/packages/typeorm/src/typeorm.data-source.ts
+++ b/packages/typeorm/src/typeorm.data-source.ts
@@ -12,13 +12,14 @@ import {
     DeleteError,
     NotFoundError,
     Logger,
+    DeviceConsoleLogger,
 } from '@mobilejazz/harmony-core';
 import { Repository as TypeORMRepository, In, Condition } from 'typeorm';
 
 export class TypeOrmDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
     constructor(
         private readonly repository: TypeORMRepository<T>,
-        private readonly logger: Logger,
+        private readonly logger: Logger = new DeviceConsoleLogger(),
     ) {}
 
     async get(query: Query): Promise<T> {


### PR DESCRIPTION
Resolves #7. Following the proposal of mobilejazz/harmony-reference#8.

- I added `console.warn` deprecation messages where needed.
- When possible, I've moved the Queries handling to the `delete` method.
- In those cases (and some others) I've also forwarded the call to the `delete` method.