### PR TITLE
New SQL Params paradigm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains the core structure for typescript of the Mobile Jazz Ha
 - `nvm use`: ensure we're using the proper NodeJS version
 - `npm ci`: install root dependencies
 - `npx lerna exec -- npm ci`: install packages dependencies
+- `npx lerna bootstrap`: replace internal modules as symlinks (required to apply changes to the library) 
 
 Anytime you're working in the project ensure you `nvm use` to stay on the correct NodeJS version.
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mobilejazz/harmony-core",
-	"version": "0.6.5",
+	"version": "0.6.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/src/repository/data-source/sql/sql-query-param-composer.ts
+++ b/packages/core/src/repository/data-source/sql/sql-query-param-composer.ts
@@ -1,0 +1,43 @@
+import {SQLDialect} from '../../../data';
+
+export type SQLQueryParamFn = (param: any) => string;
+
+/**
+ * Class that stores the list of parameters for a query and returns
+ * the parameter symbol to be used in an SQL statement when adding a new one.
+ */
+export class SQLQueryParamComposer {
+    private params: any[] = [];
+
+    /**
+     * Constructor
+     * @param dialect The associated SQL dialect
+     */
+    constructor(
+        private readonly dialect: SQLDialect,
+    ) {}
+
+    /**
+     * Add a new parameter. Returns the parameter symbol associated to the dialect to be used
+     * in an SQL statement (ex: ?, $1, ..).
+     * @param param The parameter to be added
+     */
+    public readonly push: SQLQueryParamFn = (param: any) => {
+        this.params.push(param);
+        return this.dialect.getParameterSymbol(this.params.length);
+    }
+
+    /**
+     * Returns the amount of params currently stored
+     */
+    public getCount(): number {
+        return this.params.length;
+    }
+
+    /**
+     * Returns the list of params
+     */
+    public getParams(): any[] {
+        return this.params;
+    }
+}

--- a/packages/core/src/repository/data-source/sql/sql-row-counter.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/sql-row-counter.data-source.ts
@@ -22,7 +22,7 @@ export class SQLRowCounterDataSource implements GetDataSource<number> {
             let sql = `${this.selectSQL()}`;
 
             let params = new SQLQueryParamComposer(this.sqlDialect);
-            let queryWhereSQL = query.whereSql(params);
+            let queryWhereSQL = query.where(params.push, this.sqlDialect);
             let whereSql = queryWhereSQL ? queryWhereSQL : '';
 
             if (this.softDeleteEnabled) {

--- a/packages/core/src/repository/data-source/sql/sql.query.ts
+++ b/packages/core/src/repository/data-source/sql/sql.query.ts
@@ -4,31 +4,20 @@ import {BaseColumnCreatedAt} from "./sql.constants";
 import {SQLDialect} from "../../../data";
 
 export abstract class SQLOrderByQuery extends Query implements SQLOrderBy {
-    abstract orderBy(dialect?: SQLDialect, params?: SQLQueryParamComposer): string;
-    orderByParams(): any[] {
-        return [];
-    }
+    abstract orderBy(params: SQLQueryParamComposer): string;
     abstract ascending(): boolean;
 }
 
 export abstract class SQLOrderByPaginationQuery extends PaginationOffsetLimitQuery implements SQLOrderBy {
-    abstract orderBy(dialect?: SQLDialect, params?: SQLQueryParamComposer): string;
-    orderByParams(): any[] {
-        return [];
-    }
+    abstract orderBy(params: SQLQueryParamComposer): string;
     abstract ascending(): boolean;
 }
 
 export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere {
-    abstract whereSql(dialect?: SQLDialect, params?: SQLQueryParamComposer): string;
-    abstract whereParams(): any[];
+    abstract whereSql(params: SQLQueryParamComposer): string;
 
-    orderBy(dialect?: SQLDialect, params?: SQLQueryParamComposer): string {
+    orderBy(params: SQLQueryParamComposer): string {
         return BaseColumnCreatedAt;
-    }
-
-    orderByParams(): any[] {
-        return [];
     }
 
     ascending(): boolean {
@@ -37,15 +26,10 @@ export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere 
 }
 
 export abstract class SQLWherePaginationQuery extends SQLOrderByPaginationQuery implements SQLWhere {
-    abstract whereSql(dialect?: SQLDialect, params?: SQLQueryParamComposer): string;
-    abstract whereParams(): any[];
+    abstract whereSql(params: SQLQueryParamComposer): string;
 
-    orderBy(dialect?: SQLDialect, params?: SQLQueryParamComposer): string {
+    orderBy(params: SQLQueryParamComposer): string {
         return BaseColumnCreatedAt;
-    }
-
-    orderByParams(): any[] {
-        return [];
     }
 
     ascending(): boolean {

--- a/packages/core/src/repository/data-source/sql/sql.query.ts
+++ b/packages/core/src/repository/data-source/sql/sql.query.ts
@@ -1,22 +1,22 @@
-import {PaginationOffsetLimitQuery, Query, SQLQueryParamComposer} from '../..';
+import {PaginationOffsetLimitQuery, Query, SQLQueryParamFn} from '../..';
 import {SQLOrderBy, SQLWhere} from "./raw-sql.data-source";
 import {BaseColumnCreatedAt} from "./sql.constants";
-import {SQLDialect} from "../../../data";
+import {SQLDialect} from '../../../data';
 
 export abstract class SQLOrderByQuery extends Query implements SQLOrderBy {
-    abstract orderBy(params: SQLQueryParamComposer): string;
+    abstract orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
     abstract ascending(): boolean;
 }
 
 export abstract class SQLOrderByPaginationQuery extends PaginationOffsetLimitQuery implements SQLOrderBy {
-    abstract orderBy(params: SQLQueryParamComposer): string;
+    abstract orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
     abstract ascending(): boolean;
 }
 
 export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere {
-    abstract whereSql(params: SQLQueryParamComposer): string;
+    abstract where(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
 
-    orderBy(params: SQLQueryParamComposer): string {
+    orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string {
         return BaseColumnCreatedAt;
     }
 
@@ -26,9 +26,9 @@ export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere 
 }
 
 export abstract class SQLWherePaginationQuery extends SQLOrderByPaginationQuery implements SQLWhere {
-    abstract whereSql(params: SQLQueryParamComposer): string;
+    abstract where(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
 
-    orderBy(params: SQLQueryParamComposer): string {
+    orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string {
         return BaseColumnCreatedAt;
     }
 

--- a/packages/core/src/repository/index.ts
+++ b/packages/core/src/repository/index.ts
@@ -23,3 +23,4 @@ export * from './data-source/sql/sql.query';
 export * from './data-source/sql/sql.constants';
 export * from './data-source/sql/sql-row-counter.data-source';
 export * from './data-source/sql/raw-sql.data-source';
+export * from './data-source/sql/sql-query-param-composer';

--- a/packages/nest/src/oauth/data/datasource/query/oauth-access-token.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-access-token.query.ts
@@ -1,10 +1,10 @@
-import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamFn} from '@mobilejazz/harmony-core';
 
 export class OAuthAccessTokenQuery extends SQLWhereQuery {
     constructor(
         readonly accessToken: string,
     ) { super(); }
-    whereSql(params: SQLQueryParamComposer): string {
-        return `access_token = ${params.next(this.accessToken)}`;
+    where(param: SQLQueryParamFn): string {
+        return `access_token = ${param(this.accessToken)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-access-token.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-access-token.query.ts
@@ -1,13 +1,10 @@
-import {SQLWhereQuery, SQLDialect, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
 
 export class OAuthAccessTokenQuery extends SQLWhereQuery {
     constructor(
         readonly accessToken: string,
     ) { super(); }
-    whereParams(): any[] {
-        return [this.accessToken];
-    }
-    whereSql(dialect: SQLDialect, params: SQLQueryParamComposer): string {
-        return `access_token = ${params.next()}`;
+    whereSql(params: SQLQueryParamComposer): string {
+        return `access_token = ${params.next(this.accessToken)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-client-id.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-client-id.query.ts
@@ -1,10 +1,10 @@
-import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamFn} from '@mobilejazz/harmony-core';
 
 export class OAuthClientIdQuery extends SQLWhereQuery {
     constructor(
         readonly clientId: string|number,
     ) { super(); }
-    whereSql(params: SQLQueryParamComposer): string {
-        return `client_id = ${params.next(this.clientId)}`;
+    where(param: SQLQueryParamFn): string {
+        return `client_id = ${param(this.clientId)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-client-id.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-client-id.query.ts
@@ -1,13 +1,10 @@
-import {SQLWhereQuery, SQLDialect, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
 
 export class OAuthClientIdQuery extends SQLWhereQuery {
     constructor(
         readonly clientId: string|number,
     ) { super(); }
-    whereParams(): any[] {
-        return [this.clientId];
-    }
-    whereSql(dialect: SQLDialect, params: SQLQueryParamComposer): string {
-        return `client_id = ${params.next()}`;
+    whereSql(params: SQLQueryParamComposer): string {
+        return `client_id = ${params.next(this.clientId)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-client.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-client.query.ts
@@ -1,11 +1,11 @@
-import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamFn} from '@mobilejazz/harmony-core';
 
 export class OAuthClientQuery extends SQLWhereQuery {
     constructor(
         readonly clientId: string,
         readonly clientSecret: string,
     ) { super(); }
-    whereSql(params: SQLQueryParamComposer): string {
-        return `client_id = ${params.next(this.clientId)} and client_secret = ${params.next(this.clientSecret)}`;
+    where(param: SQLQueryParamFn): string {
+        return `client_id = ${param(this.clientId)} and client_secret = ${param(this.clientSecret)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-client.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-client.query.ts
@@ -1,14 +1,11 @@
-import {SQLWhereQuery, SQLDialect, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
 
 export class OAuthClientQuery extends SQLWhereQuery {
     constructor(
         readonly clientId: string,
         readonly clientSecret: string,
     ) { super(); }
-    whereParams(): any[] {
-        return [this.clientId, this.clientSecret];
-    }
-    whereSql(dialect: SQLDialect, params: SQLQueryParamComposer): string {
-        return `client_id = ${params.next()} and client_secret = ${params.next()}`;
+    whereSql(params: SQLQueryParamComposer): string {
+        return `client_id = ${params.next(this.clientId)} and client_secret = ${params.next(this.clientSecret)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-refresh-token.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-refresh-token.query.ts
@@ -1,10 +1,10 @@
-import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamFn} from '@mobilejazz/harmony-core';
 
 export class OAuthRefreshTokenQuery extends SQLWhereQuery {
     constructor(
         readonly refreshToken: string,
     ) { super(); }
-    whereSql(params: SQLQueryParamComposer): string {
-        return `refresh_token = ${params.next(this.refreshToken)}`;
+    where(param: SQLQueryParamFn): string {
+        return `refresh_token = ${param(this.refreshToken)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-refresh-token.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-refresh-token.query.ts
@@ -1,13 +1,10 @@
-import {SQLWhereQuery, SQLDialect, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
 
 export class OAuthRefreshTokenQuery extends SQLWhereQuery {
     constructor(
         readonly refreshToken: string,
     ) { super(); }
-    whereParams(): any[] {
-        return [this.refreshToken];
-    }
-    whereSql(dialect: SQLDialect, params: SQLQueryParamComposer): string {
-        return `refresh_token = ${params.next()}`;
+    whereSql(params: SQLQueryParamComposer): string {
+        return `refresh_token = ${params.next(this.refreshToken)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-token-id.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-token-id.query.ts
@@ -1,13 +1,10 @@
-import {SQLWhereQuery, SQLDialect, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
 
 export class OAuthTokenIdQuery extends SQLWhereQuery {
     constructor(
         private readonly tokenId: string|number,
     ) { super(); }
-    whereParams(): any[] {
-        return [this.tokenId];
-    }
-    whereSql(dialect: SQLDialect, params: SQLQueryParamComposer): string {
-        return `token_id = ${params.next()}`;
+    whereSql(params: SQLQueryParamComposer): string {
+        return `token_id = ${params.next(this.tokenId)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-token-id.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-token-id.query.ts
@@ -1,10 +1,10 @@
-import {SQLWhereQuery, SQLQueryParamComposer} from '@mobilejazz/harmony-core';
+import {SQLQueryParamFn, SQLWhereQuery} from '@mobilejazz/harmony-core';
 
 export class OAuthTokenIdQuery extends SQLWhereQuery {
     constructor(
         private readonly tokenId: string|number,
     ) { super(); }
-    whereSql(params: SQLQueryParamComposer): string {
-        return `token_id = ${params.next(this.tokenId)}`;
+    where(param: SQLQueryParamFn): string {
+        return `token_id = ${param(this.tokenId)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-user-id.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-user-id.query.ts
@@ -1,10 +1,10 @@
-import {SQLDialect, SQLQueryParamComposer, SQLWhereQuery} from '@mobilejazz/harmony-core';
+import {SQLQueryParamFn, SQLWhereQuery} from '@mobilejazz/harmony-core';
 
 export class OAuthUserIdQuery extends SQLWhereQuery {
     constructor(
         readonly userId: string,
     ) { super(); }
-    whereSql(params: SQLQueryParamComposer): string {
-        return `user_id = ${params.next(this.userId)}`;
+    where(param: SQLQueryParamFn): string {
+        return `user_id = ${param(this.userId)}`;
     }
 }

--- a/packages/nest/src/oauth/data/datasource/query/oauth-user-id.query.ts
+++ b/packages/nest/src/oauth/data/datasource/query/oauth-user-id.query.ts
@@ -4,10 +4,7 @@ export class OAuthUserIdQuery extends SQLWhereQuery {
     constructor(
         readonly userId: string,
     ) { super(); }
-    whereParams(): any[] {
-        return [this.userId];
-    }
-    whereSql(dialect: SQLDialect, params: SQLQueryParamComposer): string {
-        return `user_id = ${params.next()}`;
+    whereSql(params: SQLQueryParamComposer): string {
+        return `user_id = ${params.next(this.userId)}`;
     }
 }


### PR DESCRIPTION
- Removed `orderByParams()` & `whereParams()`
- Change signature of `orderBy` & `whereSql`: removed `dialect?: SQLDialect` in favor of `params: SQLQueryParamComposer`
- Changed `SQLQueryParamComposer` to accept a value inside the method `next(param: any)`
- New method `getParams()` in `SQLQueryParamComposer`, which returns the list of params inserted via the `next(param)` method.
- Updated `RawSQLDataSource` to work with the new version of `SQLQueryParamComposer`
- Updated `SQLRowCounterDataSource` to work with the new version of `SQLQueryParamComposer`
- Updated `OAuth2` server to work with the new SQL Params paradigm

Issue: https://github.com/mobilejazz/harmony-typescript/issues/48

Note changes break backwards compatibility. This must be deployed on version 0.7.0 (incrementing Y) and projects will have to be updated.