### PR TITLE
Implements cache operation fallback

### DIFF
--- a/packages/core/src/repository/cache.repository.ts
+++ b/packages/core/src/repository/cache.repository.ts
@@ -120,15 +120,9 @@ export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, D
                     }
                     return values;
                 }).catch((err: Error) => {
-                    if (err instanceof NotValidError || err instanceof NotFoundError) {
-                        return this.getAll(query, new MainOperation()).catch((finalError: Error) => {
-                            let op = operation as CacheOperation;
-                            if (op.fallback(finalError)) {
-                                return this.getCache.getAll(query);
-                            } else {
-                                throw finalError;
-                            }
-                        });
+                    let op = operation as CacheOperation;
+                    if (err instanceof NotValidError && op.fallback(err)) {
+                        return this.getCache.getAll(query);
                     } else {
                         throw err;
                     }

--- a/packages/core/src/repository/cache.repository.ts
+++ b/packages/core/src/repository/cache.repository.ts
@@ -65,15 +65,9 @@ export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, D
                     }
                     return value;
                 }).catch((err: Error) => {
-                    if (err instanceof NotValidError || err instanceof NotFoundError) {
-                        return this.get(query, new MainOperation()).catch((finalError: Error) => {
-                            let op = operation as CacheOperation;
-                            if (op.fallback(finalError)) {
-                                return this.getCache.get(query);
-                            } else {
-                                throw finalError;
-                            }
-                        });
+                    let op = operation as CacheOperation;
+                    if (err instanceof NotValidError && op.fallback(err)) {
+                        return this.getCache.get(query);
                     } else {
                         throw err;
                     }


### PR DESCRIPTION
Implement a fallback lambda on CacheOperation to allow ignoring validation as described in this issue: mobilejazz/harmony-reference#85