### PR TITLE
Remove optionals (`?`) from SQL query signatures

### DIFF
--- a/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
@@ -19,12 +19,12 @@ import { SQLQueryParamComposer } from './sql-query-param-composer';
 export type RawSQLData = any;
 
 export interface SQLOrderBy {
-    orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
+    orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
     ascending(): boolean;
 }
 
 export interface SQLWhere {
-    where(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
+    where(param: SQLQueryParamFn, dialect: SQLDialect): string;
 }
 
 class SQLQueryComposition {

--- a/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
@@ -19,12 +19,12 @@ import { SQLQueryParamComposer } from './sql-query-param-composer';
 export type RawSQLData = any;
 
 export interface SQLOrderBy {
-    orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
+    orderBy: (param: SQLQueryParamFn, dialect: SQLDialect) => string;
     ascending(): boolean;
 }
 
 export interface SQLWhere {
-    where(param: SQLQueryParamFn, dialect: SQLDialect): string;
+    where: (param: SQLQueryParamFn, dialect: SQLDialect) => string;
 }
 
 class SQLQueryComposition {

--- a/packages/core/src/repository/data-source/sql/sql.query.ts
+++ b/packages/core/src/repository/data-source/sql/sql.query.ts
@@ -4,35 +4,35 @@ import { BaseColumnCreatedAt } from './sql.constants';
 import { SQLDialect } from '../../../data';
 
 export abstract class SQLOrderByQuery extends Query implements SQLOrderBy {
-    abstract orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
-    abstract ascending(): boolean;
+    public abstract orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
+    public abstract ascending(): boolean;
 }
 
 export abstract class SQLOrderByPaginationQuery extends PaginationOffsetLimitQuery implements SQLOrderBy {
-    abstract orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
-    abstract ascending(): boolean;
+    public abstract orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
+    public abstract ascending(): boolean;
 }
 
 export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere {
-    abstract where(param: SQLQueryParamFn, dialect: SQLDialect): string;
+    public abstract where(param: SQLQueryParamFn, dialect: SQLDialect): string;
 
-    orderBy(_param: SQLQueryParamFn, _dialect: SQLDialect): string {
+    public orderBy(): string {
         return BaseColumnCreatedAt;
     }
 
-    ascending(): boolean {
+    public ascending(): boolean {
         return false;
     }
 }
 
 export abstract class SQLWherePaginationQuery extends SQLOrderByPaginationQuery implements SQLWhere {
-    abstract where(param: SQLQueryParamFn, dialect: SQLDialect): string;
+    public abstract where(param: SQLQueryParamFn, dialect: SQLDialect): string;
 
-    orderBy(_param: SQLQueryParamFn, _dialect: SQLDialect): string {
+    public orderBy(): string {
         return BaseColumnCreatedAt;
     }
 
-    ascending(): boolean {
+    public ascending(): boolean {
         return false;
     }
 }

--- a/packages/core/src/repository/data-source/sql/sql.query.ts
+++ b/packages/core/src/repository/data-source/sql/sql.query.ts
@@ -4,19 +4,19 @@ import { BaseColumnCreatedAt } from './sql.constants';
 import { SQLDialect } from '../../../data';
 
 export abstract class SQLOrderByQuery extends Query implements SQLOrderBy {
-    abstract orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
+    abstract orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
     abstract ascending(): boolean;
 }
 
 export abstract class SQLOrderByPaginationQuery extends PaginationOffsetLimitQuery implements SQLOrderBy {
-    abstract orderBy(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
+    abstract orderBy(param: SQLQueryParamFn, dialect: SQLDialect): string;
     abstract ascending(): boolean;
 }
 
 export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere {
-    abstract where(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
+    abstract where(param: SQLQueryParamFn, dialect: SQLDialect): string;
 
-    orderBy(_param?: SQLQueryParamFn, _dialect?: SQLDialect): string {
+    orderBy(_param: SQLQueryParamFn, _dialect: SQLDialect): string {
         return BaseColumnCreatedAt;
     }
 
@@ -26,9 +26,9 @@ export abstract class SQLWhereQuery extends SQLOrderByQuery implements SQLWhere 
 }
 
 export abstract class SQLWherePaginationQuery extends SQLOrderByPaginationQuery implements SQLWhere {
-    abstract where(param?: SQLQueryParamFn, dialect?: SQLDialect): string;
+    abstract where(param: SQLQueryParamFn, dialect: SQLDialect): string;
 
-    orderBy(_param?: SQLQueryParamFn, _dialect?: SQLDialect): string {
+    orderBy(_param: SQLQueryParamFn, _dialect: SQLDialect): string {
         return BaseColumnCreatedAt;
     }
 


### PR DESCRIPTION
These values are always available so is **false** that they are optionals (remember: `T?` means `T | undefined`); with stricter TS compiler options (e.g. `strictNullCheck`) it asks to handle this possibly `undefined` value generating unnecessary boilerplate.

This is the false error this generates with `strictNullCheck`:
![image](https://user-images.githubusercontent.com/188612/139470373-b55e6c10-3987-4db1-b485-2ce4afe2d3bf.png)
`Cannot invoke an object which is possibly 'undefined'. ts(2722)`
