### PR TITLE
Fix "put" pipeline signatures

### DIFF
--- a/packages/core/src/repository/data-source/data-source.ts
+++ b/packages/core/src/repository/data-source/data-source.ts
@@ -4,15 +4,15 @@ import { Query } from '..';
 export interface DataSource {}
 
 export interface GetDataSource<T> extends DataSource {
-    get(query: Query): Promise<T>;
-    getAll(query: Query): Promise<T[]>;
+    get: (query: Query) => Promise<T>;
+    getAll: (query: Query) => Promise<T[]>;
 }
 
 export interface PutDataSource<T> extends DataSource {
-    put(value: T | undefined, query: Query): Promise<T>;
-    putAll(values: T[] | undefined, query: Query): Promise<T[]>;
+    put: (value: T | undefined, query: Query) => Promise<T>;
+    putAll: (values: T[] | undefined, query: Query) => Promise<T[]>;
 }
 
 export interface DeleteDataSource extends DataSource {
-    delete(query: Query): Promise<void>;
+    delete: (query: Query) => Promise<void>;
 }

--- a/packages/core/src/repository/data-source/data-source.ts
+++ b/packages/core/src/repository/data-source/data-source.ts
@@ -9,8 +9,8 @@ export interface GetDataSource<T> extends DataSource {
 }
 
 export interface PutDataSource<T> extends DataSource {
-    put(value: T, query: Query): Promise<T>;
-    putAll(values: T[], query: Query): Promise<T[]>;
+    put(value: T | undefined, query: Query): Promise<T>;
+    putAll(values: T[] | undefined, query: Query): Promise<T[]>;
 }
 
 export interface DeleteDataSource extends DataSource {

--- a/packages/core/src/repository/interactor/put-all.interactor.ts
+++ b/packages/core/src/repository/interactor/put-all.interactor.ts
@@ -4,7 +4,7 @@ export class PutAllInteractor<T> {
     constructor(private readonly repository: PutRepository<T>) {}
 
     public execute(
-        values: T[],
+        values: T[] | undefined,
         query: Query = new VoidQuery(),
         operation: Operation = new DefaultOperation(),
     ): Promise<T[]> {

--- a/packages/core/src/repository/interactor/put.interactor.ts
+++ b/packages/core/src/repository/interactor/put.interactor.ts
@@ -4,7 +4,7 @@ export class PutInteractor<T> {
     constructor(private readonly repository: PutRepository<T>) {}
 
     public execute(
-        value: T,
+        value: T | undefined,
         query: Query = new VoidQuery(),
         operation: Operation = new DefaultOperation(),
     ): Promise<T> {

--- a/packages/core/src/repository/repository.ts
+++ b/packages/core/src/repository/repository.ts
@@ -5,15 +5,15 @@ import { Query } from './query/query';
 export interface Repository {}
 
 export interface GetRepository<T> extends Repository {
-    get(query: Query, operation: Operation): Promise<T>;
-    getAll(query: Query, operation: Operation): Promise<T[]>;
+    get: (query: Query, operation: Operation) => Promise<T>;
+    getAll: (query: Query, operation: Operation) => Promise<T[]>;
 }
 
 export interface PutRepository<T> extends Repository {
-    put(value: T | undefined, query: Query, operation: Operation): Promise<T>;
-    putAll(values: T[] | undefined, query: Query, operation: Operation): Promise<T[]>;
+    put: (value: T | undefined, query: Query, operation: Operation) => Promise<T>;
+    putAll: (values: T[] | undefined, query: Query, operation: Operation) => Promise<T[]>;
 }
 
 export interface DeleteRepository extends Repository {
-    delete(query: Query, operation: Operation): Promise<void>;
+    delete: (query: Query, operation: Operation) => Promise<void>;
 }

--- a/packages/core/src/repository/repository.ts
+++ b/packages/core/src/repository/repository.ts
@@ -10,8 +10,8 @@ export interface GetRepository<T> extends Repository {
 }
 
 export interface PutRepository<T> extends Repository {
-    put(value: T, query: Query, operation: Operation): Promise<T>;
-    putAll(values: T[], query: Query, operation: Operation): Promise<T[]>;
+    put(value: T | undefined, query: Query, operation: Operation): Promise<T>;
+    putAll(values: T[] | undefined, query: Query, operation: Operation): Promise<T[]>;
 }
 
 export interface DeleteRepository extends Repository {


### PR DESCRIPTION
- All `put` pipelines interfaces changed to explicitly define `undefined` as an union type.
- `Put/PutAll` interactors updated with the new signature
- Interface signatures changed to arrow functions so that projects in _strict_ mode benefit of better signature checking. See: [Stack Overflow](https://stackoverflow.com/questions/69807243/why-typescript-doesnt-enforce-interface-signature) & [TS docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html#strict-function-types).
- Fixes #26.