### PR TITLE
Repurpose `Repository` & `DataSource` to express the combination of get/put/delete types

### DIFF
--- a/examples/backend/src/domain/app.provider.ts
+++ b/examples/backend/src/domain/app.provider.ts
@@ -1,11 +1,9 @@
 import {
     createCacheDecorator,
     DataSourceMapper,
-    DeleteRepository,
     GetInteractor,
-    GetRepository,
     GetRepositoryMapper,
-    PutRepository,
+    Repository,
     RepositoryMapper,
     SingleDataSourceRepository,
     SingleGetDataSourceRepository,
@@ -44,9 +42,7 @@ export class AppDefaultProvider implements AppProvider {
     ) {}
 
     @Cached()
-    private getUserRepository(): GetRepository<UserModel> &
-        PutRepository<UserModel> &
-        DeleteRepository {
+    private getUserRepository(): Repository<UserModel> {
         const rawDataSource = new UserMysqlDataSource(
             this.dialect,
             this.db,

--- a/packages/core/src/repository/cache.repository.ts
+++ b/packages/core/src/repository/cache.repository.ts
@@ -3,7 +3,7 @@ import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source/da
 import { NotFoundError, NotValidError, OperationNotSupportedError } from './errors';
 import { DefaultOperation, Operation } from './operation/operation';
 import { Query } from './query/query';
-import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { Repository } from './repository';
 
 export class MainOperation implements Operation {}
 export class MainSyncOperation implements Operation {}
@@ -36,7 +36,7 @@ export class DefaultObjectValidator implements ObjectValidator {
     }
 }
 
-export class CacheRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
+export class CacheRepository<T> implements Repository<T> {
     constructor(
         private readonly getMain: GetDataSource<T>,
         private readonly putMain: PutDataSource<T>,

--- a/packages/core/src/repository/data-source/data-source.ts
+++ b/packages/core/src/repository/data-source/data-source.ts
@@ -1,18 +1,17 @@
 import { Query } from '..';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface DataSource {}
-
-export interface GetDataSource<T> extends DataSource {
+export interface GetDataSource<T> {
     get: (query: Query) => Promise<T>;
     getAll: (query: Query) => Promise<T[]>;
 }
 
-export interface PutDataSource<T> extends DataSource {
+export interface PutDataSource<T> {
     put: (value: T | undefined, query: Query) => Promise<T>;
     putAll: (values: T[] | undefined, query: Query) => Promise<T[]>;
 }
 
-export interface DeleteDataSource extends DataSource {
+export interface DeleteDataSource {
     delete: (query: Query) => Promise<void>;
 }
+
+export type DataSource<T> = GetDataSource<T> & PutDataSource<T> & DeleteDataSource;

--- a/packages/core/src/repository/data-source/in-memory.data-source.ts
+++ b/packages/core/src/repository/data-source/in-memory.data-source.ts
@@ -1,17 +1,15 @@
 import {
     AllObjectsQuery,
-    DeleteDataSource,
-    GetDataSource,
+    DataSource,
     IdsQuery,
     InvalidArgumentError,
     KeyQuery,
-    PutDataSource,
     Query,
     QueryNotSupportedError,
 } from '..';
 import { DeviceConsoleLogger, Logger } from '../../helpers';
 
-export class InMemoryDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
+export class InMemoryDataSource<T> implements DataSource<T> {
     private objects: Record<string, T> = {};
     private arrays: Record<string, T[]> = {};
 

--- a/packages/core/src/repository/data-source/mock.data-source.ts
+++ b/packages/core/src/repository/data-source/mock.data-source.ts
@@ -1,8 +1,8 @@
-import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
+import { DataSource } from './data-source';
 import { Query } from '..';
 import { DeviceConsoleLogger, Logger } from '../../helpers';
 
-export class MockDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
+export class MockDataSource<T> implements DataSource<T> {
     constructor(
         private readonly one: T,
         private readonly many: T[],

--- a/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
+++ b/packages/core/src/repository/data-source/sql/raw-sql.data-source.ts
@@ -1,4 +1,4 @@
-import { DeleteDataSource, GetDataSource, PutDataSource } from '../data-source';
+import { DataSource } from '../data-source';
 import { InvalidArgumentError, NotFoundError, QueryNotSupportedError } from '../../errors';
 import {
     BaseColumnCreatedAt,
@@ -31,7 +31,7 @@ class SQLQueryComposition {
     constructor(readonly query: string, readonly params: unknown[]) {}
 }
 
-export class RawSQLDataSource implements GetDataSource<RawSQLData>, PutDataSource<RawSQLData>, DeleteDataSource {
+export class RawSQLDataSource implements DataSource<RawSQLData> {
     constructor(
         protected readonly sqlDialect: SQLDialect,
         protected readonly sqlInterface: SQLInterface,

--- a/packages/core/src/repository/data-source/storage.data-source.ts
+++ b/packages/core/src/repository/data-source/storage.data-source.ts
@@ -8,10 +8,10 @@ import {
     QueryNotSupportedError,
     InvalidArgumentError,
 } from '..';
-import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
+import { DataSource } from './data-source';
 import { Logger, SafeStorage, VoidLogger } from '../../helpers';
 
-export class StorageDataSource implements GetDataSource<string>, PutDataSource<string>, DeleteDataSource {
+export class StorageDataSource implements DataSource<string> {
     private readonly storage: Storage;
 
     /**

--- a/packages/core/src/repository/data-source/void.data-source.ts
+++ b/packages/core/src/repository/data-source/void.data-source.ts
@@ -1,8 +1,8 @@
-import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
+import { DataSource, DeleteDataSource, GetDataSource, PutDataSource } from './data-source';
 import { MethodNotImplementedError, Query } from '..';
 import { DeviceConsoleLogger, Logger } from '../../helpers';
 
-export class VoidDataSource<T> implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource {
+export class VoidDataSource<T> implements DataSource<T> {
     constructor(private readonly logger: Logger = new DeviceConsoleLogger()) {}
 
     public async get(_query: Query): Promise<T> {

--- a/packages/core/src/repository/repository-mapper.ts
+++ b/packages/core/src/repository/repository-mapper.ts
@@ -1,7 +1,7 @@
 import { Mapper } from './mapper/mapper';
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
-import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { DeleteRepository, GetRepository, PutRepository, Repository } from './repository';
 import { DeviceConsoleLogger, Logger } from '../helpers';
 
 /**
@@ -13,7 +13,7 @@ import { DeviceConsoleLogger, Logger } from '../helpers';
  * @param toOutMapper Mapper to map data objects to domain objects
  * @param toInMapper Mapper to map domain objects to data objects
  */
-export class RepositoryMapper<In, Out> implements GetRepository<Out>, PutRepository<Out>, DeleteRepository {
+export class RepositoryMapper<In, Out> implements Repository<Out> {
     private readonly getMapper: GetRepositoryMapper<In, Out>;
     private readonly putMapper: PutRepositoryMapper<In, Out>;
 

--- a/packages/core/src/repository/repository.ts
+++ b/packages/core/src/repository/repository.ts
@@ -1,19 +1,18 @@
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Repository {}
-
-export interface GetRepository<T> extends Repository {
+export interface GetRepository<T> {
     get: (query: Query, operation: Operation) => Promise<T>;
     getAll: (query: Query, operation: Operation) => Promise<T[]>;
 }
 
-export interface PutRepository<T> extends Repository {
+export interface PutRepository<T> {
     put: (value: T | undefined, query: Query, operation: Operation) => Promise<T>;
     putAll: (values: T[] | undefined, query: Query, operation: Operation) => Promise<T[]>;
 }
 
-export interface DeleteRepository extends Repository {
+export interface DeleteRepository {
     delete: (query: Query, operation: Operation) => Promise<void>;
 }
+
+export type Repository<T> = GetRepository<T> & PutRepository<T> & DeleteRepository;

--- a/packages/core/src/repository/single-data-source.repository.ts
+++ b/packages/core/src/repository/single-data-source.repository.ts
@@ -1,10 +1,10 @@
 import { DeleteDataSource, GetDataSource, PutDataSource } from './data-source/data-source';
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
-import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { DeleteRepository, GetRepository, PutRepository, Repository } from './repository';
 import { DeviceConsoleLogger, Logger } from '../helpers';
 
-export class SingleDataSourceRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
+export class SingleDataSourceRepository<T> implements Repository<T> {
     constructor(
         private readonly getDataSource: GetDataSource<T>,
         private readonly putDataSource: PutDataSource<T>,

--- a/packages/core/src/repository/void.repository.ts
+++ b/packages/core/src/repository/void.repository.ts
@@ -1,10 +1,10 @@
 import { MethodNotImplementedError } from './errors';
 import { Operation } from './operation/operation';
 import { Query } from './query/query';
-import { DeleteRepository, GetRepository, PutRepository } from './repository';
+import { DeleteRepository, GetRepository, PutRepository, Repository } from './repository';
 import { DeviceConsoleLogger, Logger } from '../helpers';
 
-export class VoidRepository<T> implements GetRepository<T>, PutRepository<T>, DeleteRepository {
+export class VoidRepository<T> implements Repository<T> {
     constructor(private readonly logger: Logger = new DeviceConsoleLogger()) {}
 
     public async get(_query: Query, _operation: Operation): Promise<T> {

--- a/packages/typeorm/src/typeorm.data-source.ts
+++ b/packages/typeorm/src/typeorm.data-source.ts
@@ -1,13 +1,10 @@
 import type { Repository as TypeORMRepository, ObjectLiteral, FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
 import {
-    DeleteDataSource,
     ObjectQuery,
     ObjectRelationsQuery,
-    GetDataSource,
     IdQuery,
     IdsQuery,
-    PutDataSource,
     Query,
     QueryNotSupportedError,
     VoidQuery,
@@ -17,11 +14,10 @@ import {
     DeviceConsoleLogger,
     InvalidArgumentError,
     BaseColumnId,
+    DataSource,
 } from '@mobilejazz/harmony-core';
 
-export class TypeOrmDataSource<T extends ObjectLiteral>
-    implements GetDataSource<T>, PutDataSource<T>, DeleteDataSource
-{
+export class TypeOrmDataSource<T extends ObjectLiteral> implements DataSource<T> {
     constructor(
         private readonly repository: TypeORMRepository<T>,
         private readonly idColumn = BaseColumnId,


### PR DESCRIPTION
Repurpose `Repository` & `DataSource` to allow a generic `T` so that it now expresses the combination of all three basic get/put/delete interfaces. Code simplified where possible.

Closes #88 
