### PR TITLE
BACKEND-1429 :: Feature-Internal :: Use abstract classes for SQLInterface & SQLDialect (for DI)

### DIFF
--- a/examples/backend/src/domain/app.provider.module.ts
+++ b/examples/backend/src/domain/app.provider.module.ts
@@ -18,7 +18,7 @@ const interactors = [
     providers: [
         {
             provide: AppProvider,
-            inject: ['SQLDialect', 'SQLInterface'],
+            inject: [SQLDialect, SQLInterface],
             useFactory: (dialect: SQLDialect, db: SQLInterface) =>
                 new AppDefaultProvider(dialect, db),
         },

--- a/packages/core/src/data/sql.dialect.ts
+++ b/packages/core/src/data/sql.dialect.ts
@@ -1,8 +1,8 @@
-export interface SQLDialect {
-    getParameterSymbol: (idx?: number) => string;
-    getInsertionId: (result: unknown, idColumn: string) => number;
-    getInsertionIdQueryStatement: (idColumn: string) => string;
-    getTableName: (tableName: string) => string;
-    getCountName: () => string;
-    mapError: (error: Error) => Error;
+export abstract class SQLDialect {
+    abstract getParameterSymbol: (idx?: number) => string;
+    abstract getInsertionId: (result: unknown, idColumn: string) => number;
+    abstract getInsertionIdQueryStatement: (idColumn: string) => string;
+    abstract getTableName: (tableName: string) => string;
+    abstract getCountName: () => string;
+    abstract mapError: (error: Error) => Error;
 }

--- a/packages/core/src/data/sql.interface.ts
+++ b/packages/core/src/data/sql.interface.ts
@@ -1,4 +1,4 @@
-export interface SQLInterface {
-    query: <T = unknown>(query: string, parameters?: unknown[]) => Promise<T>;
-    transaction: <T>(runInTransaction: (sqlInterface: SQLInterface) => Promise<T>) => Promise<T>;
+export abstract class SQLInterface {
+    abstract query: <T = unknown>(query: string, parameters?: unknown[]) => Promise<T>;
+    abstract transaction: <T>(runInTransaction: (sqlInterface: SQLInterface) => Promise<T>) => Promise<T>;
 }

--- a/packages/core/src/helpers/utilities.ts
+++ b/packages/core/src/helpers/utilities.ts
@@ -24,8 +24,8 @@ export function createCacheDecorator(): CacheDecorator {
 
                 return cache.get(propertyKey);
             };
-        }
-    }
+        };
+    };
 }
 
 export class UnreachableCaseError extends Error {

--- a/packages/nest/src/app/database.module.ts
+++ b/packages/nest/src/app/database.module.ts
@@ -2,7 +2,7 @@ import { DynamicModule, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DataSource, EntityManager } from 'typeorm';
 import { TypeORMSQLInterface } from '@mobilejazz/harmony-typeorm';
-import { MySQLDialect, PostgresSQLDialect, SQLDialect } from '@mobilejazz/harmony-core';
+import { MySQLDialect, PostgresSQLDialect, SQLDialect, SQLInterface } from '@mobilejazz/harmony-core';
 
 export interface DatabaseModuleParams {
     dataSource: DataSource;
@@ -17,12 +17,12 @@ export class DatabaseModule {
             imports: [TypeOrmModule.forRoot(params.dataSource.options)],
             providers: [
                 {
-                    provide: 'SQLInterface',
+                    provide: SQLInterface,
                     inject: [EntityManager],
                     useFactory: (entityManager: EntityManager) => new TypeORMSQLInterface(entityManager),
                 },
                 {
-                    provide: 'SQLDialect',
+                    provide: SQLDialect,
                     inject: [],
                     useFactory: (): SQLDialect => {
                         switch (params.dataSource.options.type) {
@@ -38,7 +38,7 @@ export class DatabaseModule {
                     },
                 },
             ],
-            exports: ['SQLInterface', 'SQLDialect'],
+            exports: [SQLInterface, SQLDialect],
         };
     }
 }

--- a/packages/nest/src/app/filters/http-exception.filter.ts
+++ b/packages/nest/src/app/filters/http-exception.filter.ts
@@ -1,4 +1,4 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException, InternalServerErrorException, Type } from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, InternalServerErrorException } from '@nestjs/common';
 import { Mapper } from '@mobilejazz/harmony-core';
 import { Request, Response } from 'express';
 import { getI18nContextFromRequest, I18nService } from 'nestjs-i18n';

--- a/packages/nest/src/app/oauth.module.ts
+++ b/packages/nest/src/app/oauth.module.ts
@@ -28,7 +28,7 @@ export class OAuthModule {
             providers: [
                 {
                     provide: OAuth2Server,
-                    inject: ['SQLDialect', 'SQLInterface', params.getUser, params.loginUser, params.validateScope],
+                    inject: [SQLDialect, SQLInterface, params.getUser, params.loginUser, params.validateScope],
                     useFactory: (
                         dialect: SQLDialect,
                         sqlInterface: SQLInterface,


### PR DESCRIPTION
**:link: Asana: https://app.asana.com/0/1109863238977521/1203174773901429/f**

### Description

- Make `SQLInterface` & `SQLDialect` abstract so they can be used directly as injection tokens
- Change providers to reference these classes directly instead of using the strings



