### PR TITLE
Update bcrypt cost factor

### DIFF
--- a/packages/nest/src/security/crypto.utils.ts
+++ b/packages/nest/src/security/crypto.utils.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto';
 import { compare, hash, hashSync } from 'bcryptjs';
 
 export class CryptoUtils {
-    private static readonly saltIteration = 5;
+    private static readonly saltIteration = 12;
 
     static passwordHashAlgorithm(): string {
         return `bcryptjs::hash_it${this.saltIteration}`;


### PR DESCRIPTION
Bcrypt has a configurable cost factor to increase the difficulty of brute-force password guessing. It is recommended that this cost is increased over time as computation power increases. A cost of 12 takes around 250ms on a modern computer, which is acceptable in most cases. A minimum cost of 10 is recommended nowadays.