### PR TITLE
FRONTEND-1411 :: Feature Internal :: Change harmony-core `class-transformer` dependency into a `peerDependency`

### DIFF
--- a/examples/angular/angular.json
+++ b/examples/angular/angular.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "$schema": "../../node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
                 "examples/*",
                 "packages/*"
             ],
-            "dependencies": {
-                "@bugfender/sdk": "^2.1.0"
-            },
             "devDependencies": {
                 "@types/jest": "^28.1.8",
                 "@types/node": "16.x",
@@ -6857,6 +6854,7 @@
             "version": "1.0.0-alpha.5",
             "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.0.0-alpha.5.tgz",
             "integrity": "sha512-t6vWPc64lF12YczMtR89aCZSdnq3aOxuSRy4dQ7s+5/99jQziw9Duvg0YSCoEX7ptciR2qVT5ElSIwFEk9mDMg==",
+            "dev": true,
             "dependencies": {
                 "util": "^0.12.4"
             }
@@ -6865,6 +6863,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.1.0.tgz",
             "integrity": "sha512-IzixkqA/ltA4A/GmLNGeLcFKJwZmrwC9s3Q0K+DjUMoD1Eb6OXB8f3vVWAIVnbfP0zYWtxCbtMb77IFfyBXNvQ==",
+            "peer": true,
             "dependencies": {
                 "base-58": "0.0.1",
                 "bowser": "^2.11.0",
@@ -12393,6 +12392,7 @@
             "version": "2.15.21",
             "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
             "integrity": "sha512-NPotx5CVful7yB+qZbWtXL2fA4e7aEHkihHLjklc6ID8aq7bhguHgeIoC1EmSNTAuCgI6ZXrjt2ZSaXnYX0EUg==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -12400,7 +12400,8 @@
         "node_modules/@types/node": {
             "version": "16.11.62",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.62.tgz",
-            "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ=="
+            "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==",
+            "devOptional": true
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -13727,7 +13728,8 @@
         "node_modules/base-58": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/base-58/-/base-58-0.0.1.tgz",
-            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw=="
+            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw==",
+            "peer": true
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -13955,7 +13957,8 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "peer": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -13981,6 +13984,7 @@
             "version": "4.17.0",
             "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.17.0.tgz",
             "integrity": "sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "oblivious-set": "1.1.1",
@@ -15646,6 +15650,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
             "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -15997,6 +16002,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
             "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+            "peer": true,
             "dependencies": {
                 "stackframe": "^1.3.4"
             }
@@ -20449,7 +20455,8 @@
         "node_modules/js-sha256": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+            "peer": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -22815,7 +22822,8 @@
         "node_modules/oblivious-set": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
-            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
+            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w==",
+            "peer": true
         },
         "node_modules/obuf": {
             "version": "1.1.2",
@@ -25930,6 +25938,7 @@
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
             "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+            "peer": true,
             "dependencies": {
                 "stackframe": "^1.3.4"
             }
@@ -25958,7 +25967,8 @@
         "node_modules/stackframe": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+            "peer": true
         },
         "node_modules/statuses": {
             "version": "2.0.1",
@@ -27156,6 +27166,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz",
             "integrity": "sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "2.1.0"
@@ -28217,7 +28228,7 @@
             "name": "@mobilejazz/harmony-bugfender",
             "version": "0.10.0",
             "license": "Apache-2.0",
-            "dependencies": {
+            "devDependencies": {
                 "@bugfender/common": "^1.0.0-alpha.5"
             },
             "peerDependencies": {
@@ -28229,15 +28240,21 @@
             "name": "@mobilejazz/harmony-core",
             "version": "0.10.0",
             "license": "Apache-2.0",
-            "dependencies": {
-                "@types/mysql": "^2.15.21",
-                "class-transformer": "^0.4.0"
+            "devDependencies": {
+                "@types/mysql": "^2.15.21"
+            },
+            "optionalDependencies": {
+                "mysql": "2.x"
+            },
+            "peerDependencies": {
+                "class-transformer": ">=0.2.0"
             }
         },
         "packages/core/node_modules/class-transformer": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
-            "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
+            "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==",
+            "peer": true
         },
         "packages/nest": {
             "name": "@mobilejazz/harmony-nest",
@@ -28245,20 +28262,21 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "bcryptjs": "~2.4.3",
-                "oauth2-server": "^3.1.1",
-                "reflect-metadata": "^0.1.13"
+                "oauth2-server": "^3.1.1"
             },
             "devDependencies": {
                 "@types/bcryptjs": "~2.4.2",
                 "@types/oauth2-server": "^3.0.13"
             },
-            "peerDependencies": {
-                "@mobilejazz/harmony-core": "*",
-                "@mobilejazz/harmony-typeorm": "*",
-                "@nestjs/common": "^9.0.0",
+            "optionalDependencies": {
                 "@nestjs/swagger": "^6.0.0",
                 "@nestjs/typeorm": "^9.0.0",
                 "nestjs-i18n": "^9.0.0"
+            },
+            "peerDependencies": {
+                "@mobilejazz/harmony-core": "*",
+                "@mobilejazz/harmony-typeorm": "*",
+                "@nestjs/common": "^9.0.0"
             }
         },
         "packages/typeorm": {
@@ -32729,6 +32747,7 @@
             "version": "1.0.0-alpha.5",
             "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.0.0-alpha.5.tgz",
             "integrity": "sha512-t6vWPc64lF12YczMtR89aCZSdnq3aOxuSRy4dQ7s+5/99jQziw9Duvg0YSCoEX7ptciR2qVT5ElSIwFEk9mDMg==",
+            "dev": true,
             "requires": {
                 "util": "^0.12.4"
             }
@@ -32737,6 +32756,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.1.0.tgz",
             "integrity": "sha512-IzixkqA/ltA4A/GmLNGeLcFKJwZmrwC9s3Q0K+DjUMoD1Eb6OXB8f3vVWAIVnbfP0zYWtxCbtMb77IFfyBXNvQ==",
+            "peer": true,
             "requires": {
                 "base-58": "0.0.1",
                 "bowser": "^2.11.0",
@@ -35625,24 +35645,27 @@
             "version": "file:packages/core",
             "requires": {
                 "@types/mysql": "^2.15.21",
-                "class-transformer": "^0.4.0"
+                "mysql": "2.x"
             },
             "dependencies": {
                 "class-transformer": {
                     "version": "0.4.0",
                     "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
-                    "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
+                    "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==",
+                    "peer": true
                 }
             }
         },
         "@mobilejazz/harmony-nest": {
             "version": "file:packages/nest",
             "requires": {
+                "@nestjs/swagger": "^6.0.0",
+                "@nestjs/typeorm": "^9.0.0",
                 "@types/bcryptjs": "~2.4.2",
                 "@types/oauth2-server": "^3.0.13",
                 "bcryptjs": "~2.4.3",
-                "oauth2-server": "^3.1.1",
-                "reflect-metadata": "^0.1.13"
+                "nestjs-i18n": "^9.0.0",
+                "oauth2-server": "^3.1.1"
             }
         },
         "@mobilejazz/harmony-typeorm": {
@@ -37164,6 +37187,7 @@
             "version": "2.15.21",
             "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
             "integrity": "sha512-NPotx5CVful7yB+qZbWtXL2fA4e7aEHkihHLjklc6ID8aq7bhguHgeIoC1EmSNTAuCgI6ZXrjt2ZSaXnYX0EUg==",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -37171,7 +37195,8 @@
         "@types/node": {
             "version": "16.11.62",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.62.tgz",
-            "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ=="
+            "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==",
+            "devOptional": true
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -38293,7 +38318,8 @@
         "base-58": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/base-58/-/base-58-0.0.1.tgz",
-            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw=="
+            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw==",
+            "peer": true
         },
         "base64-js": {
             "version": "1.5.1",
@@ -38487,7 +38513,8 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "peer": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -38510,6 +38537,7 @@
             "version": "4.17.0",
             "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.17.0.tgz",
             "integrity": "sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==",
+            "peer": true,
             "requires": {
                 "@babel/runtime": "^7.16.0",
                 "oblivious-set": "1.1.1",
@@ -39749,7 +39777,8 @@
         "dexie": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
-            "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg=="
+            "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
+            "peer": true
         },
         "dezalgo": {
             "version": "1.0.4",
@@ -40024,6 +40053,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
             "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+            "peer": true,
             "requires": {
                 "stackframe": "^1.3.4"
             }
@@ -43619,7 +43649,8 @@
         "js-sha256": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+            "peer": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -45456,7 +45487,8 @@
         "oblivious-set": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
-            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
+            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w==",
+            "peer": true
         },
         "obuf": {
             "version": "1.1.2",
@@ -47735,6 +47767,7 @@
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
             "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+            "peer": true,
             "requires": {
                 "stackframe": "^1.3.4"
             }
@@ -47759,7 +47792,8 @@
         "stackframe": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+            "peer": true
         },
         "statuses": {
             "version": "2.0.1",
@@ -48545,6 +48579,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz",
             "integrity": "sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==",
+            "peer": true,
             "requires": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "scripts": {
         "bootstrap": "lerna bootstrap --use-workspaces --hoist --force-local",
         "check-deps": "npm outdated && lerna exec -- npm outdated && npm audit && lerna exec -- npm audit",
+        "clean": "lerna clean",
         "prebuild": "npm run validate && npm run format",
         "build": "lerna run build",
         "lint": "lerna run lint",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
         "prepare": "husky install",
         "setup": "npm ci && npm run bootstrap && npm run build"
     },
-    "dependencies": {
-        "@bugfender/sdk": "^2.1.0"
-    },
     "devDependencies": {
         "@types/jest": "^28.1.8",
         "@types/node": "16.x",

--- a/packages/bugfender/package.json
+++ b/packages/bugfender/package.json
@@ -19,7 +19,7 @@
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
         "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
     },
-    "dependencies": {
+    "devDependencies": {
         "@bugfender/common": "^1.0.0-alpha.5"
     },
     "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,8 +19,13 @@
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
         "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
     },
-    "dependencies": {
-        "@types/mysql": "^2.15.21",
-        "class-transformer": "^0.4.0"
+    "devDependencies": {
+        "@types/mysql": "^2.15.21"
+    },
+    "peerDependencies": {
+        "class-transformer": ">=0.2.0"
+    },
+    "optionalDependencies": {
+        "mysql": "2.x"
     }
 }

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -21,8 +21,7 @@
     },
     "dependencies": {
         "bcryptjs": "~2.4.3",
-        "oauth2-server": "^3.1.1",
-        "reflect-metadata": "^0.1.13"
+        "oauth2-server": "^3.1.1"
     },
     "devDependencies": {
         "@types/bcryptjs": "~2.4.2",
@@ -31,7 +30,9 @@
     "peerDependencies": {
         "@mobilejazz/harmony-core": "*",
         "@mobilejazz/harmony-typeorm": "*",
-        "@nestjs/common": "^9.0.0",
+        "@nestjs/common": "^9.0.0"
+    },
+    "optionalDependencies": {
         "@nestjs/swagger": "^6.0.0",
         "@nestjs/typeorm": "^9.0.0",
         "nestjs-i18n": "^9.0.0"


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203249744541411/f**

- Move some `package.json` dependencies to sections that better fit their usage (peer, optional, dev).
- Make `harmony-core` `class-transformer` constraint so it allows wider range of versions; and move it to 'peerDeps' to avoid [issues with `class-transformer` metadata storage](https://github.com/typestack/class-transformer/issues/36#issuecomment-540543193)
- Move some `harmony-nest` to "optional" as they're only needed if certain features from `harmony-nest` are used
- Remove some unused packages
- When a dep is only needed for its types, move to `dev` section
