### PR TITLE
FRONTEND-1215 :: Feature :: Add `createAngularProviders` in a similar way to `createNestProviders`

### DIFF
--- a/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.module.ts
+++ b/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.module.ts
@@ -1,26 +1,21 @@
+import { NgModule } from '@angular/core';
+import { createAngularProviders } from '@mobilejazz/harmony-angular';
+
 import { HackerNewsStoryProvider } from './hacker-news-story.provider';
 import { GetHackerNewsLatestAskStoriesInteractor } from './domain/interactors/get-hacker-news-latest-ask-stories.interactor';
 import { GetHackerNewsStoryInteractor } from './domain/interactors/get-hacker-news-story.interactor';
 import { HackerNewsStoryDefaultProvider } from "./hacker-news-story.provider";
-import { NgModule } from "@angular/core";
 
 @NgModule({
-  providers: [
+  providers: createAngularProviders(
     {
       provide: HackerNewsStoryProvider,
-      deps: [],
       useFactory: () => new HackerNewsStoryDefaultProvider(),
     },
-    {
-      provide: GetHackerNewsLatestAskStoriesInteractor,
-      deps: [HackerNewsStoryProvider],
-      useFactory: (provider: HackerNewsStoryProvider) => provider.getHackerNewsLatestAskStories(),
-    },
-    {
-      provide: GetHackerNewsStoryInteractor,
-      deps: [HackerNewsStoryProvider],
-      useFactory: (provider: HackerNewsStoryProvider) => provider.getHackerNewsStory(),
-    },
-  ]
+    [
+      GetHackerNewsLatestAskStoriesInteractor,
+      GetHackerNewsStoryInteractor,
+    ],
+  ),
 })
 export class HackerNewsStoryProviderModule {}

--- a/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
+++ b/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
@@ -23,8 +23,8 @@ import { HackerNewsStoryIdsNetworkDataSource } from "./data/data-sources/hacker-
 const Cached = createCacheDecorator();
 
 export abstract class HackerNewsStoryProvider {
-  abstract getGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor;
-  abstract getGetHackerNewsStory(): GetHackerNewsStoryInteractor;
+  abstract provideGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor;
+  abstract provideGetHackerNewsStory(): GetHackerNewsStoryInteractor;
 }
 
 export class HackerNewsStoryDefaultProvider implements HackerNewsStoryProvider {
@@ -62,14 +62,14 @@ export class HackerNewsStoryDefaultProvider implements HackerNewsStoryProvider {
     );
   }
 
-  public getGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor {
+  public provideGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor {
     return new GetHackerNewsLatestAskStoriesInteractor(
-      this.getGetHackerNewsStory(),
+      this.provideGetHackerNewsStory(),
       new GetInteractor(this.getHackerNewsStoryIdsRepository()),
     );
   }
 
-  public getGetHackerNewsStory(): GetHackerNewsStoryInteractor {
+  public provideGetHackerNewsStory(): GetHackerNewsStoryInteractor {
     return new GetHackerNewsStoryInteractor(
       new GetInteractor(this.getHackerNewsStoryRepository()),
     );

--- a/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
+++ b/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
@@ -23,8 +23,8 @@ import { HackerNewsStoryIdsNetworkDataSource } from "./data/data-sources/hacker-
 const Cached = createCacheDecorator();
 
 export abstract class HackerNewsStoryProvider {
-  abstract getHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor;
-  abstract getHackerNewsStory(): GetHackerNewsStoryInteractor;
+  abstract getGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor;
+  abstract getGetHackerNewsStory(): GetHackerNewsStoryInteractor;
 }
 
 export class HackerNewsStoryDefaultProvider implements HackerNewsStoryProvider {
@@ -62,14 +62,14 @@ export class HackerNewsStoryDefaultProvider implements HackerNewsStoryProvider {
     );
   }
 
-  public getHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor {
+  public getGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor {
     return new GetHackerNewsLatestAskStoriesInteractor(
-      this.getHackerNewsStory(),
+      this.getGetHackerNewsStory(),
       new GetInteractor(this.getHackerNewsStoryIdsRepository()),
     );
   }
 
-  public getHackerNewsStory(): GetHackerNewsStoryInteractor {
+  public getGetHackerNewsStory(): GetHackerNewsStoryInteractor {
     return new GetHackerNewsStoryInteractor(
       new GetInteractor(this.getHackerNewsStoryRepository()),
     );

--- a/examples/backend/src/domain/app.provider.module.ts
+++ b/examples/backend/src/domain/app.provider.module.ts
@@ -1,29 +1,25 @@
 import { SQLDialect, SQLInterface } from '@mobilejazz/harmony-core';
-import { createNestProviders } from '@mobilejazz/harmony-nest';
+import { createNestProviderModuleMetadata } from '@mobilejazz/harmony-nest';
 import { Global, Module } from '@nestjs/common';
 
 import { AppDefaultProvider, AppProvider } from 'src/domain/app.provider';
 import { GetBasicUserInteractor } from './interactors/auth/get-basic-user.interactor';
 import { LoginUserInteractor } from './interactors/auth/login-user.interactor';
 import { ValidateUserScopeInteractor } from './interactors/auth/validate-user-scope.interactor';
-
-const interactors = [
-    GetBasicUserInteractor,
-    LoginUserInteractor,
-    ValidateUserScopeInteractor,
-];
-
 @Global()
-@Module({
-    providers: [
+@Module(
+    createNestProviderModuleMetadata(
         {
             provide: AppProvider,
             inject: [SQLDialect, SQLInterface],
             useFactory: (dialect: SQLDialect, db: SQLInterface) =>
                 new AppDefaultProvider(dialect, db),
         },
-        ...createNestProviders(AppProvider, interactors),
-    ],
-    exports: [AppProvider, ...interactors],
-})
+        [
+            GetBasicUserInteractor,
+            LoginUserInteractor,
+            ValidateUserScopeInteractor,
+        ],
+    ),
+)
 export class AppProviderModule {}

--- a/examples/backend/src/domain/app.provider.module.ts
+++ b/examples/backend/src/domain/app.provider.module.ts
@@ -6,6 +6,7 @@ import { AppDefaultProvider, AppProvider } from 'src/domain/app.provider';
 import { GetBasicUserInteractor } from './interactors/auth/get-basic-user.interactor';
 import { LoginUserInteractor } from './interactors/auth/login-user.interactor';
 import { ValidateUserScopeInteractor } from './interactors/auth/validate-user-scope.interactor';
+
 @Global()
 @Module(
     createNestProviderModuleMetadata(

--- a/examples/backend/src/domain/app.provider.ts
+++ b/examples/backend/src/domain/app.provider.ts
@@ -28,9 +28,9 @@ import {
 } from './mappers/user.mapper';
 
 export abstract class AppProvider {
-    abstract getGetBasicUser(): GetBasicUserInteractor;
-    abstract getLoginUser(): LoginUserInteractor;
-    abstract getValidateUserScope(): ValidateUserScopeInteractor;
+    abstract provideGetBasicUser(): GetBasicUserInteractor;
+    abstract provideLoginUser(): LoginUserInteractor;
+    abstract provideValidateUserScope(): ValidateUserScopeInteractor;
 }
 
 const Cached = createCacheDecorator();
@@ -72,13 +72,13 @@ export class AppDefaultProvider implements AppProvider {
         );
     }
 
-    public getGetBasicUser(): GetBasicUserInteractor {
+    public provideGetBasicUser(): GetBasicUserInteractor {
         return new GetBasicUserInteractor(
             new GetInteractor(this.getUserRepository()),
         );
     }
 
-    public getLoginUser(): LoginUserInteractor {
+    public provideLoginUser(): LoginUserInteractor {
         const dataSource = new OauthUserInfoMysqlDataSource(
             this.dialect,
             this.db,
@@ -91,7 +91,7 @@ export class AppDefaultProvider implements AppProvider {
         return new LoginUserInteractor(new GetInteractor(repo));
     }
 
-    public getValidateUserScope(): ValidateUserScopeInteractor {
+    public provideValidateUserScope(): ValidateUserScopeInteractor {
         return new ValidateUserScopeInteractor();
     }
 }

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,1 +1,2 @@
-export * from './public-api';
+export * from './http-request.builder';
+export * from './utilities';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -1,1 +1,0 @@
-export * from './http-request.builder';

--- a/packages/angular/src/utilities.ts
+++ b/packages/angular/src/utilities.ts
@@ -1,12 +1,11 @@
 import { Provider, FactoryProvider, Type } from '@angular/core';
-
-type HarmonyProvider = Record<string, () => unknown>;
+import { HarmonyProvider } from '@mobilejazz/harmony-core';
 
 export function createAngularProviders(provider: FactoryProvider, interactors: Type<unknown>[]): Provider[] {
     const providers: Provider[] = [provider];
 
     interactors.forEach((interactor) => {
-        const method = `get${interactor.name.replace('Interactor', '')}`;
+        const method = `provide${interactor.name.replace('Interactor', '')}`;
 
         providers.push({
             provide: interactor,

--- a/packages/angular/src/utilities.ts
+++ b/packages/angular/src/utilities.ts
@@ -1,0 +1,19 @@
+import { Provider, FactoryProvider, Type } from '@angular/core';
+
+type HarmonyProvider = Record<string, () => unknown>;
+
+export function createAngularProviders(provider: FactoryProvider, interactors: Type<unknown>[]): Provider[] {
+    const providers: Provider[] = [provider];
+
+    interactors.forEach((interactor) => {
+        const method = `get${interactor.name.replace('Interactor', '')}`;
+
+        providers.push({
+            provide: interactor,
+            deps: [provider.provide],
+            useFactory: (providerInstance: HarmonyProvider) => providerInstance[method](),
+        });
+    });
+
+    return providers;
+}

--- a/packages/core/src/helpers/types.ts
+++ b/packages/core/src/helpers/types.ts
@@ -5,3 +5,10 @@
 export interface Type<T> extends Function {
     new (...args: unknown[]): T;
 }
+
+/**
+ * Loose type that represents a Harmony Provider.
+ *
+ * Needed as a _helper type_ for Angular/Nest `*ProviderModule` helpers.
+ */
+export type HarmonyProvider = Record<`provide${string}`, () => unknown>;

--- a/packages/nest/src/app/utilities.ts
+++ b/packages/nest/src/app/utilities.ts
@@ -1,13 +1,21 @@
-import { FactoryProvider, InjectionToken, Provider, Type } from '@nestjs/common';
+import { HarmonyProvider } from '@mobilejazz/harmony-core';
+import { FactoryProvider, ModuleMetadata, Provider, Type } from '@nestjs/common';
 
-export function createNestProviders(provider: InjectionToken, interactors: Type[]): Provider[] {
-    return interactors.map<FactoryProvider>((interactor) => {
-        const method = `get${interactor.name.replace('Interactor', '')}`;
+export function createNestProviderModuleMetadata(provider: FactoryProvider, interactors: Type[]): ModuleMetadata {
+    const providers: Provider[] = [provider];
 
-        return {
+    interactors.forEach((interactor) => {
+        const method = `provide${interactor.name.replace('Interactor', '')}`;
+
+        providers.push({
             provide: interactor,
-            inject: [provider],
-            useFactory: (providerInstance) => providerInstance[method](),
-        };
+            inject: [provider.provide],
+            useFactory: (providerInstance: HarmonyProvider) => providerInstance[method](),
+        });
     });
+
+    return {
+        providers,
+        exports: [provider.provide, ...interactors],
+    };
 }


### PR DESCRIPTION
Asana task link: https://app.asana.com/0/1109863238977521/1203355492851215/f

**Merge / Pull request information:**

- Add `createAngularProviders` that simplifies glue code between a pure TS Harmony provider and the Angular module.
- This follows the same pattern to [`createNestProviders`](https://github.com/mobilejazz/harmony-typescript/blob/master/packages/nest/src/app/utilities.ts#L3)

---

- [x] Unify signature between `createAngularProviders` & `createNestProviders`
- [x] Explore the idea of decorator composition, [I've opened a question in SO](https://stackoverflow.com/questions/74429904/angular-ngmodule-decorator-composition-error-ng6002).