### PR TITLE
FRONTEND-3512 :: Bug :: Relax `Type<T>` and `HttpRequestBuilder` return types

### DIFF
--- a/packages/angular/src/http-request.builder.ts
+++ b/packages/angular/src/http-request.builder.ts
@@ -62,7 +62,11 @@ export class HttpRequestBuilder<T> {
         return mapper.map(responseItem);
     }
 
-    private mapResponse(res: HttpResponse<T>): T | T[] | undefined {
+    // HACK: This is problematic but it's the best we can do right now.
+    // Let's assume that `T` equals to the return type of this `mapResponse`.
+    // See: https://app.asana.com/0/1109863238977521/1203450043003508/f
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private mapResponse(res: HttpResponse<T>): any {
         if (!res.body) {
             return undefined;
         }
@@ -80,19 +84,19 @@ export class HttpRequestBuilder<T> {
         return this.mapItem(res.body);
     }
 
-    public get(): Observable<T | T[] | undefined> {
+    public get(): Observable<T> {
         return this.http
             .get<T>(this.urlBuilder.getUrl(), { observe: 'response', headers: this.headers })
             .pipe(map((res) => this.mapResponse(res)));
     }
 
-    public post(): Observable<T | T[] | undefined> {
+    public post(): Observable<T> {
         return this.http
             .post<T>(this.urlBuilder.getUrl(), this.body, { observe: 'response', headers: this.headers })
             .pipe(map((res) => this.mapResponse(res)));
     }
 
-    public put(): Observable<T | T[] | undefined> {
+    public put(): Observable<T> {
         return this.http
             .put<T>(this.urlBuilder.getUrl(), this.body, { observe: 'response', headers: this.headers })
             .pipe(map((res) => this.mapResponse(res)));

--- a/packages/core/src/helpers/types.ts
+++ b/packages/core/src/helpers/types.ts
@@ -3,7 +3,9 @@
  * @see https://stackoverflow.com/a/52183279/379923
  */
 export interface Type<T> extends Function {
-    new (...args: unknown[]): T;
+    // In this case, it must be `any`. Using `unknown` give compile errors.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (...args: any[]): T;
 }
 
 /**


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203450043003512/f**

- Fix `Type<T>`, so it matches Angular/Nest ones
- Relax `HttpRequestBuilder` return types
