### PR TITLE
FRONTEND-3555 :: Feature :: Merge Logger & AbstractLogger and improve API

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -19,8 +19,10 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
-    "@mobilejazz/harmony-angular": "^0.11.0",
-    "@mobilejazz/harmony-core": "^0.11.0",
+    "@bugfender/sdk": "^2.2.0",
+    "@mobilejazz/harmony-angular": "*",
+    "@mobilejazz/harmony-bugfender": "*",
+    "@mobilejazz/harmony-core": "*",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/examples/angular/src/features/hacker-news-story/domain/interactors/get-hacker-news-latest-ask-stories.interactor.ts
+++ b/examples/angular/src/features/hacker-news-story/domain/interactors/get-hacker-news-latest-ask-stories.interactor.ts
@@ -1,4 +1,4 @@
-import { GetInteractor } from '@mobilejazz/harmony-core';
+import { GetInteractor, Logger } from '@mobilejazz/harmony-core';
 
 import { GetHackerNewsLatestAskStoriesQuery } from '../../data/queries/hacker-news.query';
 import { HackerNewsStory } from '../models/hacker-news-story.model';
@@ -8,9 +8,12 @@ export class GetHackerNewsLatestAskStoriesInteractor {
   constructor(
     private readonly getStory: GetHackerNewsStoryInteractor,
     private readonly getLatestAskStoryIds: GetInteractor<number[]>,
+    private readonly logger: Logger,
   ) { }
 
-  public async execute(limit: number = 5): Promise<HackerNewsStory[]> {
+  public async execute(limit = 5): Promise<HackerNewsStory[]> {
+    this.logger.log('Getting latest news from Hacker News');
+
     const ids = await this.getLatestAskStoryIds.execute(new GetHackerNewsLatestAskStoriesQuery());
 
     return Promise.all(

--- a/examples/angular/src/features/hacker-news-story/domain/interactors/get-hacker-news-story.interactor.ts
+++ b/examples/angular/src/features/hacker-news-story/domain/interactors/get-hacker-news-story.interactor.ts
@@ -1,4 +1,4 @@
-import { GetInteractor } from '@mobilejazz/harmony-core';
+import { GetInteractor, Logger } from '@mobilejazz/harmony-core';
 
 import { GetHackerNewsStoryQuery } from '../../data/queries/hacker-news.query';
 import { HackerNewsStory } from '../models/hacker-news-story.model';
@@ -6,9 +6,11 @@ import { HackerNewsStory } from '../models/hacker-news-story.model';
 export class GetHackerNewsStoryInteractor {
   constructor(
     private readonly getStory: GetInteractor<HackerNewsStory>,
+    private readonly logger: Logger,
   ) { }
 
   public async execute(id: number): Promise<HackerNewsStory> {
+    this.logger.log('Getting story: %s', id);
     return this.getStory.execute(new GetHackerNewsStoryQuery(id));
   }
 }

--- a/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.module.ts
+++ b/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.module.ts
@@ -10,7 +10,9 @@ import { HackerNewsStoryDefaultProvider } from "./hacker-news-story.provider";
   providers: createAngularProviders(
     {
       provide: HackerNewsStoryProvider,
-      useFactory: () => new HackerNewsStoryDefaultProvider(),
+      useFactory: () => new HackerNewsStoryDefaultProvider(
+        // 'BUGFENDER_APP_KEY'
+      ),
     },
     [
       GetHackerNewsLatestAskStoriesInteractor,

--- a/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
+++ b/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
@@ -2,13 +2,17 @@ import {
   CacheRepository,
   createCacheDecorator,
   DefaultObjectValidator,
+  DeviceConsoleLogger,
   GetInteractor,
   GetRepository,
   InMemoryDataSource,
+  Logger,
   RepositoryMapper,
   SingleGetDataSourceRepository,
   VoidDataSource
 } from '@mobilejazz/harmony-core';
+import { BugfenderLogger } from '@mobilejazz/harmony-bugfender';
+import { Bugfender } from '@bugfender/sdk';
 import { HackerNewsStoryNetworkDataSource } from './data/data-sources/hacker-news-story.network.data-source';
 import { HackerNewsStoryEntity } from './data/entities/hacker-news-item.entity';
 import { HackerNewsStoryJSONToHackerNewsStoryEntityMapper } from './data/mappers/hacker-news-story.mapper';
@@ -29,6 +33,24 @@ export abstract class HackerNewsStoryProvider {
 
 export class HackerNewsStoryDefaultProvider implements HackerNewsStoryProvider {
   private readonly hackerNewsService: HackerNewsService = new HackerNewsFetchService();
+
+  constructor(
+    private readonly bugfenderAppKey?: string,
+  ) {}
+
+  @Cached()
+  private getLogger(): Logger {
+    if (this.bugfenderAppKey) {
+      Bugfender.init({
+        appKey: this.bugfenderAppKey,
+        overrideConsoleMethods: false,
+      });
+
+      return new BugfenderLogger(Bugfender);
+    }
+
+    return new DeviceConsoleLogger();
+  }
 
   @Cached()
   private getHackerNewsStoryIdsRepository(): GetRepository<number[]> {
@@ -63,15 +85,21 @@ export class HackerNewsStoryDefaultProvider implements HackerNewsStoryProvider {
   }
 
   public provideGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor {
+    this.getLogger().info('Creating instance: GetHackerNewsLatestAskStoriesInteractor');
+
     return new GetHackerNewsLatestAskStoriesInteractor(
       this.provideGetHackerNewsStory(),
       new GetInteractor(this.getHackerNewsStoryIdsRepository()),
+      this.getLogger().withTag(GetHackerNewsLatestAskStoriesInteractor),
     );
   }
 
   public provideGetHackerNewsStory(): GetHackerNewsStoryInteractor {
+    this.getLogger().info('Creating instance: GetHackerNewsStoryInteractor');
+
     return new GetHackerNewsStoryInteractor(
       new GetInteractor(this.getHackerNewsStoryRepository()),
+      this.getLogger().withTag(GetHackerNewsStoryInteractor),
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,9 @@
                 "@angular/platform-browser": "~13.3.0",
                 "@angular/platform-browser-dynamic": "~13.3.0",
                 "@angular/router": "~13.3.0",
+                "@bugfender/sdk": "^2.2.0",
                 "@mobilejazz/harmony-angular": "^0.11.0",
+                "@mobilejazz/harmony-bugfender": "^0.11.0",
                 "@mobilejazz/harmony-core": "^0.11.0",
                 "rxjs": "~7.5.0",
                 "tslib": "^2.3.0",
@@ -6851,28 +6853,26 @@
             "dev": true
         },
         "node_modules/@bugfender/common": {
-            "version": "1.0.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.0.0-alpha.5.tgz",
-            "integrity": "sha512-t6vWPc64lF12YczMtR89aCZSdnq3aOxuSRy4dQ7s+5/99jQziw9Duvg0YSCoEX7ptciR2qVT5ElSIwFEk9mDMg==",
-            "dev": true,
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.1.1.tgz",
+            "integrity": "sha512-4eytPGD3/8x2xIfTrz9Pj84Dlid4HgiMIADE4N0HfFv/l2Z8M/bfzaFJ/W7iBVjLbgxSxA/hfgc5+KETc75bwQ==",
             "dependencies": {
-                "util": "^0.12.4"
+                "util": "^0.12.5"
             }
         },
         "node_modules/@bugfender/sdk": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.1.0.tgz",
-            "integrity": "sha512-IzixkqA/ltA4A/GmLNGeLcFKJwZmrwC9s3Q0K+DjUMoD1Eb6OXB8f3vVWAIVnbfP0zYWtxCbtMb77IFfyBXNvQ==",
-            "peer": true,
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.2.0.tgz",
+            "integrity": "sha512-2NoEjNGx/DA597Eq4qCJbjfWM5TE42u1Rqs/5lmWDbDl3jjSA0ixVhjTevrfuDeN5dlY32IjY1gavKYwNueI5A==",
             "dependencies": {
+                "@bugfender/common": "^1.1.0",
                 "base-58": "0.0.1",
                 "bowser": "^2.11.0",
-                "broadcast-channel": "^4.10.0",
-                "dexie": "^3.2.1",
-                "error-stack-parser": "^2.0.7",
+                "broadcast-channel": "^4.18.1",
+                "error-stack-parser": "^2.1.4",
+                "idb": "^7.1.0",
                 "js-sha256": "^0.9.0",
-                "stack-generator": "^2.0.5",
-                "util": "^0.12.4"
+                "stack-generator": "^2.0.10"
             }
         },
         "node_modules/@colors/colors": {
@@ -13728,8 +13728,7 @@
         "node_modules/base-58": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/base-58/-/base-58-0.0.1.tgz",
-            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw==",
-            "peer": true
+            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw=="
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -13957,8 +13956,7 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "peer": true
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -13981,16 +13979,18 @@
             }
         },
         "node_modules/broadcast-channel": {
-            "version": "4.17.0",
-            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.17.0.tgz",
-            "integrity": "sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==",
-            "peer": true,
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.18.1.tgz",
+            "integrity": "sha512-eV1srWgt6H4hbtGqD7THn60me66WA5l0LogpssuX9jK6NK26HzIZr+VsrlD7Obe0BtYnwoo/a4v4z5gfty04DA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "oblivious-set": "1.1.1",
                 "p-queue": "6.6.2",
                 "rimraf": "3.0.2",
                 "unload": "2.3.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/pubkey"
             }
         },
         "node_modules/browser-process-hrtime": {
@@ -15646,15 +15646,6 @@
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
         },
-        "node_modules/dexie": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
-            "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
-            "peer": true,
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
         "node_modules/dezalgo": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -16002,7 +15993,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
             "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-            "peer": true,
             "dependencies": {
                 "stackframe": "^1.3.4"
             }
@@ -18299,6 +18289,11 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/idb": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+            "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -20455,8 +20450,7 @@
         "node_modules/js-sha256": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-            "peer": true
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -22822,8 +22816,7 @@
         "node_modules/oblivious-set": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
-            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w==",
-            "peer": true
+            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
         },
         "node_modules/obuf": {
             "version": "1.1.2",
@@ -25938,7 +25931,6 @@
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
             "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
-            "peer": true,
             "dependencies": {
                 "stackframe": "^1.3.4"
             }
@@ -25967,8 +25959,7 @@
         "node_modules/stackframe": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-            "peer": true
+            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
         },
         "node_modules/statuses": {
             "version": "2.0.1",
@@ -27166,7 +27157,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz",
             "integrity": "sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "2.1.0"
@@ -27236,15 +27226,14 @@
             }
         },
         "node_modules/util": {
-            "version": "0.12.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-            "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
                 "is-generator-function": "^1.0.7",
                 "is-typed-array": "^1.1.3",
-                "safe-buffer": "^5.1.2",
                 "which-typed-array": "^1.1.2"
             }
         },
@@ -28229,10 +28218,10 @@
             "version": "0.11.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@bugfender/common": "^1.0.0-alpha.5"
+                "@bugfender/common": "^1.1.1"
             },
             "peerDependencies": {
-                "@bugfender/sdk": "2.x",
+                "@bugfender/sdk": "^2.2.0",
                 "@mobilejazz/harmony-core": "*"
             }
         },
@@ -32744,28 +32733,26 @@
             "dev": true
         },
         "@bugfender/common": {
-            "version": "1.0.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.0.0-alpha.5.tgz",
-            "integrity": "sha512-t6vWPc64lF12YczMtR89aCZSdnq3aOxuSRy4dQ7s+5/99jQziw9Duvg0YSCoEX7ptciR2qVT5ElSIwFEk9mDMg==",
-            "dev": true,
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.1.1.tgz",
+            "integrity": "sha512-4eytPGD3/8x2xIfTrz9Pj84Dlid4HgiMIADE4N0HfFv/l2Z8M/bfzaFJ/W7iBVjLbgxSxA/hfgc5+KETc75bwQ==",
             "requires": {
-                "util": "^0.12.4"
+                "util": "^0.12.5"
             }
         },
         "@bugfender/sdk": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.1.0.tgz",
-            "integrity": "sha512-IzixkqA/ltA4A/GmLNGeLcFKJwZmrwC9s3Q0K+DjUMoD1Eb6OXB8f3vVWAIVnbfP0zYWtxCbtMb77IFfyBXNvQ==",
-            "peer": true,
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.2.0.tgz",
+            "integrity": "sha512-2NoEjNGx/DA597Eq4qCJbjfWM5TE42u1Rqs/5lmWDbDl3jjSA0ixVhjTevrfuDeN5dlY32IjY1gavKYwNueI5A==",
             "requires": {
+                "@bugfender/common": "^1.1.0",
                 "base-58": "0.0.1",
                 "bowser": "^2.11.0",
-                "broadcast-channel": "^4.10.0",
-                "dexie": "^3.2.1",
-                "error-stack-parser": "^2.0.7",
+                "broadcast-channel": "^4.18.1",
+                "error-stack-parser": "^2.1.4",
+                "idb": "^7.1.0",
                 "js-sha256": "^0.9.0",
-                "stack-generator": "^2.0.5",
-                "util": "^0.12.4"
+                "stack-generator": "^2.0.10"
             }
         },
         "@colors/colors": {
@@ -35638,7 +35625,7 @@
         "@mobilejazz/harmony-bugfender": {
             "version": "file:packages/bugfender",
             "requires": {
-                "@bugfender/common": "^1.0.0-alpha.5"
+                "@bugfender/common": "^1.1.1"
             }
         },
         "@mobilejazz/harmony-core": {
@@ -38318,8 +38305,7 @@
         "base-58": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/base-58/-/base-58-0.0.1.tgz",
-            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw==",
-            "peer": true
+            "integrity": "sha512-denlKTnozZTVWuh1QkbXf10kkFNc+0/eno29RR+6g5al0yGI+iAOFt/cIA2tvnKoADlUFLZHs50ZdWF+c9WBnw=="
         },
         "base64-js": {
             "version": "1.5.1",
@@ -38513,8 +38499,7 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "peer": true
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -38534,10 +38519,9 @@
             }
         },
         "broadcast-channel": {
-            "version": "4.17.0",
-            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.17.0.tgz",
-            "integrity": "sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==",
-            "peer": true,
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.18.1.tgz",
+            "integrity": "sha512-eV1srWgt6H4hbtGqD7THn60me66WA5l0LogpssuX9jK6NK26HzIZr+VsrlD7Obe0BtYnwoo/a4v4z5gfty04DA==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
                 "oblivious-set": "1.1.1",
@@ -39774,12 +39758,6 @@
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
         },
-        "dexie": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
-            "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
-            "peer": true
-        },
         "dezalgo": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -40053,7 +40031,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
             "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-            "peer": true,
             "requires": {
                 "stackframe": "^1.3.4"
             }
@@ -41432,7 +41409,9 @@
                 "@angular/platform-browser": "~13.3.0",
                 "@angular/platform-browser-dynamic": "~13.3.0",
                 "@angular/router": "~13.3.0",
+                "@bugfender/sdk": "^2.2.0",
                 "@mobilejazz/harmony-angular": "^0.11.0",
+                "@mobilejazz/harmony-bugfender": "*",
                 "@mobilejazz/harmony-core": "^0.11.0",
                 "@types/jest": "^27.5.2",
                 "@types/node": "^12.11.1",
@@ -41977,6 +41956,11 @@
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
             "dev": true,
             "requires": {}
+        },
+        "idb": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+            "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
         },
         "ieee754": {
             "version": "1.2.1",
@@ -43649,8 +43633,7 @@
         "js-sha256": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-            "peer": true
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -45487,8 +45470,7 @@
         "oblivious-set": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
-            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w==",
-            "peer": true
+            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
         },
         "obuf": {
             "version": "1.1.2",
@@ -47767,7 +47749,6 @@
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
             "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
-            "peer": true,
             "requires": {
                 "stackframe": "^1.3.4"
             }
@@ -47792,8 +47773,7 @@
         "stackframe": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-            "peer": true
+            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
         },
         "statuses": {
             "version": "2.0.1",
@@ -48579,7 +48559,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz",
             "integrity": "sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==",
-            "peer": true,
             "requires": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "2.1.0"
@@ -48626,15 +48605,14 @@
             }
         },
         "util": {
-            "version": "0.12.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-            "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "requires": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
                 "is-generator-function": "^1.0.7",
                 "is-typed-array": "^1.1.3",
-                "safe-buffer": "^5.1.2",
                 "which-typed-array": "^1.1.2"
             }
         },

--- a/packages/bugfender/package.json
+++ b/packages/bugfender/package.json
@@ -20,10 +20,10 @@
         "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
     },
     "devDependencies": {
-        "@bugfender/common": "^1.0.0-alpha.5"
+        "@bugfender/common": "^1.1.1"
     },
     "peerDependencies": {
-        "@bugfender/sdk": "2.x",
+        "@bugfender/sdk": "^2.2.0",
         "@mobilejazz/harmony-core": "*"
     }
 }

--- a/packages/bugfender/src/bugfender.logger.ts
+++ b/packages/bugfender/src/bugfender.logger.ts
@@ -4,6 +4,14 @@ import type { DeviceKeyValue } from '@bugfender/common';
 
 export class BugfenderLogger extends Logger {
     private tag?: string;
+    private readonly LEVEL_MAP: Record<LogLevel, BFLogLevel> = {
+        [LogLevel.Fatal]: BFLogLevel.Fatal,
+        [LogLevel.Error]: BFLogLevel.Error,
+        [LogLevel.Warning]: BFLogLevel.Warning,
+        [LogLevel.Info]: BFLogLevel.Info,
+        [LogLevel.Debug]: BFLogLevel.Debug,
+        [LogLevel.Trace]: BFLogLevel.Trace,
+    };
 
     constructor(protected bugfender: BugfenderClass, tag?: string) {
         super();
@@ -23,17 +31,8 @@ export class BugfenderLogger extends Logger {
     }
 
     protected handleLog(level: LogLevel, parameters: unknown[]): void {
-        const levelMap: Record<LogLevel, BFLogLevel> = {
-            [LogLevel.Fatal]: BFLogLevel.Fatal,
-            [LogLevel.Error]: BFLogLevel.Error,
-            [LogLevel.Warning]: BFLogLevel.Warning,
-            [LogLevel.Info]: BFLogLevel.Info,
-            [LogLevel.Debug]: BFLogLevel.Debug,
-            [LogLevel.Trace]: BFLogLevel.Trace,
-        };
-
         this.bugfender.sendLog({
-            level: levelMap[level],
+            level: this.LEVEL_MAP[level],
             tag: this.tag,
             text: parameters,
         });

--- a/packages/bugfender/src/bugfender.logger.ts
+++ b/packages/bugfender/src/bugfender.logger.ts
@@ -1,4 +1,4 @@
-import { Logger, LogLevel, UnknownLogLevelError } from '@mobilejazz/harmony-core';
+import { Logger, LogLevel } from '@mobilejazz/harmony-core';
 import { BugfenderClass, LogLevel as BFLogLevel } from '@bugfender/sdk';
 import type { DeviceKeyValue } from '@bugfender/common';
 

--- a/packages/bugfender/src/bugfender.logger.ts
+++ b/packages/bugfender/src/bugfender.logger.ts
@@ -1,10 +1,13 @@
-import { AbstractLogger, LogLevel, UnknownLogLevelError } from '@mobilejazz/harmony-core';
-import { BugfenderClass } from '@bugfender/sdk';
+import { Logger, LogLevel, UnknownLogLevelError } from '@mobilejazz/harmony-core';
+import { BugfenderClass, LogLevel as BFLogLevel } from '@bugfender/sdk';
 import type { DeviceKeyValue } from '@bugfender/common';
 
-export class BugfenderLogger extends AbstractLogger {
-    constructor(protected bugfender: BugfenderClass) {
+export class BugfenderLogger extends Logger {
+    private tag?: string;
+
+    constructor(protected bugfender: BugfenderClass, tag?: string) {
         super();
+        this.tag = tag;
     }
 
     public logKeyValue(key: string, value: DeviceKeyValue): void {
@@ -15,43 +18,24 @@ export class BugfenderLogger extends AbstractLogger {
         }
     }
 
-    public log(level: LogLevel, message: string): void;
-    public log(level: LogLevel, tag: string, message: string): void;
-    public log(level: LogLevel, tagOrMessage: string, message?: string): void {
-        const hasTag = typeof message !== 'undefined';
+    protected createLoggerWithTag(tag: string): Logger {
+        return new BugfenderLogger(this.bugfender, tag);
+    }
 
-        if (hasTag) {
-            const tag = tagOrMessage;
+    protected handleLog(level: LogLevel, parameters: unknown[]): void {
+        const levelMap: Record<LogLevel, BFLogLevel> = {
+            [LogLevel.Fatal]: BFLogLevel.Fatal,
+            [LogLevel.Error]: BFLogLevel.Error,
+            [LogLevel.Warning]: BFLogLevel.Warning,
+            [LogLevel.Info]: BFLogLevel.Info,
+            [LogLevel.Debug]: BFLogLevel.Debug,
+            [LogLevel.Trace]: BFLogLevel.Trace,
+        };
 
-            this.bugfender.sendLog({
-                tag: tag,
-                text: message,
-            });
-        } else {
-            message = tagOrMessage;
-
-            switch (level) {
-                case LogLevel.Fatal:
-                    return this.bugfender.fatal(message);
-
-                case LogLevel.Error:
-                    return this.bugfender.error(message);
-
-                case LogLevel.Warning:
-                    return this.bugfender.warn(message);
-
-                case LogLevel.Info:
-                    return this.bugfender.info(message);
-
-                case LogLevel.Debug:
-                    return this.bugfender.log(message);
-
-                case LogLevel.Trace:
-                    return this.bugfender.trace(message);
-
-                default:
-                    throw new UnknownLogLevelError();
-            }
-        }
+        this.bugfender.sendLog({
+            level: levelMap[level],
+            tag: this.tag,
+            text: parameters,
+        });
     }
 }

--- a/packages/core/src/helpers/logger/device-console.logger.ts
+++ b/packages/core/src/helpers/logger/device-console.logger.ts
@@ -19,8 +19,6 @@ export class DeviceConsoleLogger extends Logger {
     }
 
     protected handleLog(level: LogLevel, parameters: unknown[]): void {
-        parameters = parameters ?? [];
-
         if (this.tag) {
             const tagStr = `[${this.tag}]`;
 

--- a/packages/core/src/helpers/logger/device-console.logger.ts
+++ b/packages/core/src/helpers/logger/device-console.logger.ts
@@ -18,7 +18,7 @@ export class DeviceConsoleLogger extends Logger {
         return new DeviceConsoleLogger(this.logger, tag);
     }
 
-    protected handleLog(level: LogLevel, parameters: unknown[] = []): void {
+    protected handleLog(level: LogLevel, parameters: unknown[]): void {
         if (this.tag) {
             const tagStr = `[${this.tag}]`;
 

--- a/packages/core/src/helpers/logger/device-console.logger.ts
+++ b/packages/core/src/helpers/logger/device-console.logger.ts
@@ -24,11 +24,22 @@ export class DeviceConsoleLogger extends Logger {
         if (this.tag) {
             const tagStr = `[${this.tag}]`;
 
+            // Our API is compatible with `console.*` methods this means that there are two ways of using this API:
+            //
+            // - With an array of mixed values
+            // - With a template as first parameter: `[string, ...unknown[]]`. See: https://developer.mozilla.org/en-US/docs/Web/API/console#using_string_substitutions
+            //
+            // This affects how we handle the "tag". If it's an array of mixed values, we can simply prepend
+            // the tag to the `parameters` array. But, if we're using the template signature we don't want to mess
+            // with the template, that's why we prepend the tag to the template string. This way the first parameter
+            // is still (potentially) a template.
             if (parameters.length === 0 || typeof parameters[0] !== 'string') {
-                // Set tag as first parameters array element
+                // CASE: array of mixed values
+                // Add tag in the first position of the parameters array
                 parameters.unshift(tagStr);
             } else {
-                // Mix tag with parameter as it might have formatting placeholders
+                // CASE: Template with string substitutions
+                // Add tag to the first parameter as it might have formatting placeholders
                 parameters[0] = `${tagStr} ${parameters[0]}`;
             }
         }

--- a/packages/core/src/helpers/logger/device-console.logger.ts
+++ b/packages/core/src/helpers/logger/device-console.logger.ts
@@ -18,7 +18,7 @@ export class DeviceConsoleLogger extends Logger {
         return new DeviceConsoleLogger(this.logger, tag);
     }
 
-    protected handleLog(level: LogLevel, parameters: unknown[]): void {
+    protected handleLog(level: LogLevel, parameters: unknown[] = []): void {
         if (this.tag) {
             const tagStr = `[${this.tag}]`;
 

--- a/packages/core/src/helpers/logger/logger.ts
+++ b/packages/core/src/helpers/logger/logger.ts
@@ -1,3 +1,5 @@
+import { Type } from '../types';
+
 export enum LogLevel {
     Trace,
     Debug,
@@ -14,78 +16,76 @@ export class UnknownLogLevelError extends Error {
     }
 }
 
-export interface Logger {
-    logKeyValue(key: string, value: unknown): void;
+export abstract class Logger {
+    /**
+     * Log key/value pair.
+     *
+     * @param key
+     * @param value
+     */
+    public abstract logKeyValue(key: string, value: unknown): void;
 
-    log(level: LogLevel, message: string): void;
-    log(level: LogLevel, tag: string, message: string): void;
+    /**
+     * Given a tag, return a new `Logger` with that tag applied
+     *
+     * @param tag Tag that identifies this `Logger`
+     */
+    protected abstract createLoggerWithTag(tag: string): Logger;
 
-    trace(message: string): void;
-    trace(tag: string, message: string): void;
+    /**
+     * Handles incoming log
+     *
+     * @param level Log level
+     * @param parameters List of parameters to log
+     */
+    protected abstract handleLog(level: LogLevel, parameters: unknown[]): void;
 
-    debug(message: string): void;
-    debug(tag: string, message: string): void;
-
-    info(message: string): void;
-    info(tag: string, message: string): void;
-
-    warning(message: string): void;
-    warning(tag: string, message: string): void;
-
-    error(message: string): void;
-    error(tag: string, message: string): void;
-
-    fatal(message: string): void;
-    fatal(tag: string, message: string): void;
-}
-
-export abstract class AbstractLogger implements Logger {
-    abstract logKeyValue(key: string, value: unknown): void;
-
-    abstract log(level: LogLevel, message: string): void;
-    abstract log(level: LogLevel, tag: string, message: string): void;
-
-    protected _log(level: LogLevel, tagOrMessage: string, message?: string): void {
-        if (message) {
-            this.log(level, tagOrMessage, message);
-        } else {
-            this.log(level, tagOrMessage);
-        }
+    /**
+     * Returns a new `Logger` instance but with a tag/namespace applied.
+     *
+     * @param tag Tag that will be applied to logs
+     */
+    public withTag(tag: string | Type<unknown>): Logger {
+        return this.createLoggerWithTag(
+            typeof tag === 'string'
+                ? tag
+                : tag.name
+        );
     }
 
-    trace(message: string): void;
-    trace(tag: string, message: string): void;
-    trace(tagOrMessage: string, message?: string): void {
-        this._log(LogLevel.Trace, tagOrMessage, message);
+    public log(obj: unknown, ...objs: unknown[]): void;
+    public log(msg: string, ...subst: unknown[]): void;
+    public log(...parameters: unknown[]): void {
+        this.handleLog(LogLevel.Debug, parameters);
     }
 
-    debug(message: string): void;
-    debug(tag: string, message: string): void;
-    debug(tagOrMessage: string, message?: string): void {
-        this._log(LogLevel.Debug, tagOrMessage, message);
+    public warn(obj: unknown, ...objs: unknown[]): void;
+    public warn(msg: string, ...subst: unknown[]): void;
+    public warn(...parameters: unknown[]): void {
+        this.handleLog(LogLevel.Warning, parameters);
     }
 
-    info(message: string): void;
-    info(tag: string, message: string): void;
-    info(tagOrMessage: string, message?: string): void {
-        this._log(LogLevel.Info, tagOrMessage, message);
+    public error(obj: unknown, ...objs: unknown[]): void;
+    public error(msg: string, ...subst: unknown[]): void;
+    public error(...parameters: unknown[]): void {
+        this.handleLog(LogLevel.Error, parameters);
     }
 
-    warning(message: string): void;
-    warning(tag: string, message: string): void;
-    warning(tagOrMessage: string, message?: string): void {
-        this._log(LogLevel.Warning, tagOrMessage, message);
+    public trace(obj: unknown, ...objs: unknown[]): void;
+    public trace(msg: string, ...subst: unknown[]): void;
+    public trace(...parameters: unknown[]): void {
+        this.handleLog(LogLevel.Trace, parameters);
     }
 
-    error(message: string): void;
-    error(tag: string, message: string): void;
-    error(tagOrMessage: string, message?: string): void {
-        this._log(LogLevel.Error, tagOrMessage, message);
+    public info(obj: unknown, ...objs: unknown[]): void;
+    public info(msg: string, ...subst: unknown[]): void;
+    public info(...parameters: unknown[]): void {
+        this.handleLog(LogLevel.Info, parameters);
     }
 
-    fatal(message: string): void;
-    fatal(tag: string, message: string): void;
-    fatal(tagOrMessage: string, message?: string): void {
-        this._log(LogLevel.Fatal, tagOrMessage, message);
+    public fatal(obj: unknown, ...objs: unknown[]): void;
+    public fatal(msg: string, ...subst: unknown[]): void;
+    public fatal(...parameters: unknown[]): void {
+        this.handleLog(LogLevel.Fatal, parameters);
     }
 }

--- a/packages/core/src/helpers/logger/void.logger.ts
+++ b/packages/core/src/helpers/logger/void.logger.ts
@@ -1,17 +1,19 @@
-import { AbstractLogger, LogLevel } from './logger';
+import { Logger, LogLevel } from './logger';
 
-export class VoidLogger extends AbstractLogger {
+export class VoidLogger extends Logger {
     constructor() {
         super();
     }
 
-    logKeyValue(_key: string, _value: unknown): void {
+    public logKeyValue(_key: string, _value: unknown): void {
         return;
     }
 
-    log(level: LogLevel, message: string): void;
-    log(level: LogLevel, tag: string, message: string): void;
-    log(_level: LogLevel, _tagOrMessage: string, _message?: string): void {
+    protected createLoggerWithTag(_tag: string): Logger {
+        return new VoidLogger();
+    }
+
+    protected handleLog(_level: LogLevel, _parameters: unknown[]): void {
         return;
     }
 }


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203172481263555/f**

- Merge `Logger` interface and `AbstractLogger` into an abstract `Logger`
- Make logging APIs compatible with `console.*`
- Add `withTag()` factory method. This creates a new logger from a logger, but with a "tag" applied. Tags are strings that are preprended to log messages.
    - This can be a `string` or a `Type<T>`. [This is convenient (note that there aren't string quotes in `withTag()`)](https://github.com/mobilejazz/harmony-typescript/blob/de3b94b0a1cc4edd905b4b00cdf1744689b04a84/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts#L93) as it allows to set a class as the tag and is refactor friendly (e.g. "rename symbol").