### PR TITLE
FRONTEND-3523 :: Bug :: Fix `HttpRequestBuilder.setResponseConstructor` for array generics

### DIFF
--- a/packages/core/src/helpers/types.ts
+++ b/packages/core/src/helpers/types.ts
@@ -14,3 +14,14 @@ export interface Type<T> extends Function {
  * Needed as a _helper type_ for Angular/Nest `*ProviderModule` helpers.
  */
 export type HarmonyProvider = Record<`provide${string}`, () => unknown>;
+
+/**
+ * Given an array type `T[]`, removes the array part, leaving only `T`.
+ * Note that it only handles one dimensional arrays, for multiple dimensions see: https://stackoverflow.com/a/74644590/379923
+ *
+ * @see https://stackoverflow.com/a/51399781/379923
+ */
+export type ArrayElement<MaybeArrayType> =
+    MaybeArrayType extends readonly (infer ElementType)[]
+        ? ElementType
+        : MaybeArrayType;


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203450043003523/f**

Fixes the following scenario, where the generic is an array:
![image](https://user-images.githubusercontent.com/188612/205104008-781b456c-5371-41b4-a378-8273176d0d5b.png)

