### PR TITLE
FRONTEND-7708 :: Feature Internal :: Remove `createCacheDecorator` in favor of self contained `Cached` decorator

### DIFF
--- a/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
+++ b/examples/angular/src/features/hacker-news-story/hacker-news-story.provider.ts
@@ -1,6 +1,6 @@
 import {
+  Cached,
   CacheRepository,
-  createCacheDecorator,
   DefaultObjectValidator,
   DeviceConsoleLogger,
   GetInteractor,
@@ -22,9 +22,6 @@ import { GetHackerNewsStoryInteractor } from './domain/interactors/get-hacker-ne
 import { HackerNewsStoryEntityToHackerNewsStoryMapper, HackerNewsStoryToHackerNewsStoryEntityMapper } from './domain/mappers/hacker-news-story.mapper';
 import { HackerNewsStory } from './domain/models/hacker-news-story.model';
 import { HackerNewsStoryIdsNetworkDataSource } from "./data/data-sources/hacker-news-story-ids.network.data-source";
-
-// Caching via decorator
-const Cached = createCacheDecorator();
 
 export abstract class HackerNewsStoryProvider {
   abstract provideGetHackerNewsLatestAskStories(): GetHackerNewsLatestAskStoriesInteractor;

--- a/examples/backend/src/domain/app.provider.ts
+++ b/examples/backend/src/domain/app.provider.ts
@@ -1,5 +1,5 @@
 import {
-    createCacheDecorator,
+    Cached,
     DataSourceMapper,
     GetInteractor,
     GetRepositoryMapper,
@@ -32,8 +32,6 @@ export abstract class AppProvider {
     abstract provideLoginUser(): LoginUserInteractor;
     abstract provideValidateUserScope(): ValidateUserScopeInteractor;
 }
-
-const Cached = createCacheDecorator();
 
 export class AppDefaultProvider implements AppProvider {
     constructor(

--- a/packages/nest/src/oauth/oauth.sql.provider.ts
+++ b/packages/nest/src/oauth/oauth.sql.provider.ts
@@ -41,7 +41,7 @@ import { OAuthUserInfoEntityToRawSqlMapper } from './data/datasource/mappers/oau
 import { OAuthUserInfoEntity } from './data/entity/oauth-user-info.entity';
 import { GetOAuthRefreshTokenInteractor } from './domain/interactors/get-oauth-refresh-token.interactor';
 import {
-    createCacheDecorator,
+    Cached,
     DataSourceMapper,
     DeleteInteractor,
     DeleteRepository,
@@ -68,14 +68,13 @@ import { InvalidateUserTokensInteractor } from './domain/interactors/invalidate-
 import { DeleteTokensDataSource } from './data/datasource/delete-tokens.data-source';
 import { OAuthUserInfoRepository } from './data/repository/oauth-user-info.repository';
 
-const Cached = createCacheDecorator();
-
 export class OAuthSQLProvider implements OAuthProvider {
     constructor(private readonly sqlDialect: SQLDialect, private readonly sqlInterface: SQLInterface) {}
 
     public clientModel(): OAuth2BaseModel {
         return new OAuth2BaseModel(this.getClient(), this.putToken(), this.getToken(), undefined, undefined);
     }
+
     public userModel(
         getUser: GetOAuthUserInteractor,
         loginUser: LoginOAuthUserInteractor,


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203203232807708/f**

- Removes `createCacheDecorator` in favor of self contained `Cached` decorator
- In practice, this means that the decorator can be just imported and used, no need to create a `Cached` instance for each class that uses it.