### PR TITLE
FRONTEND-7941 :: Bug :: Remove @bugfender/common requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   …
+-   bugfender: FRONTEND-7941 :: Bug :: Remove `@bugfender/common` requirement ([#135])
 
 ### Security
 
 -   …
+
+[#135]: https://github.com/mobilejazz/harmony-typescript/pull/135
 
 ## [0.12.0] - 2023-01-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5872,6 +5872,7 @@
         },
         "node_modules/@babel/runtime": {
             "version": "7.16.7",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
@@ -5958,22 +5959,24 @@
             "license": "MIT"
         },
         "node_modules/@bugfender/common": {
-            "version": "1.1.1",
-            "license": "Apache-2.0",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.1.2.tgz",
+            "integrity": "sha512-mI3iSckPz5LIMelZVJ2AtvuNXqCoX4HUwo//Qu3UPRdFiJVOh34L32rNCZOq3eqEB2f4+k1aODkDbTo3PPWQ3g==",
             "dependencies": {
                 "util": "^0.12.5"
             }
         },
         "node_modules/@bugfender/sdk": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.2.2.tgz",
+            "integrity": "sha512-ZBjMElhth5hhzKqhrqRs0ahVMzhFgol2VxwOcFweYYn26QiGTeRl9sunwSVn0rGpgBKQxKLRHDIa9TXDlDeH4g==",
             "dependencies": {
-                "@bugfender/common": "^1.1.0",
+                "@bugfender/common": "^1.1.2",
                 "base-58": "0.0.1",
                 "bowser": "^2.11.0",
-                "broadcast-channel": "^4.18.1",
+                "broadcast-channel": "^4.19.1",
                 "error-stack-parser": "^2.1.4",
-                "idb": "^7.1.0",
+                "idb": "^7.1.1",
                 "js-sha256": "^0.9.0",
                 "stack-generator": "^2.0.10"
             }
@@ -12068,7 +12071,8 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -12521,18 +12525,35 @@
             }
         },
         "node_modules/broadcast-channel": {
-            "version": "4.18.1",
-            "license": "MIT",
+            "version": "4.20.2",
+            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.20.2.tgz",
+            "integrity": "sha512-v0lJgMzC+MX4e2KCFWYXChZ2mKTqm5mnJGId6tqJp3NfylggbNd8c2uKeP4MQxD2ucKOesY68aN98zwl9d6Tvg==",
             "dependencies": {
-                "@babel/runtime": "^7.16.0",
+                "@babel/runtime": "7.20.7",
                 "oblivious-set": "1.1.1",
                 "p-queue": "6.6.2",
                 "rimraf": "3.0.2",
-                "unload": "2.3.1"
+                "unload": "2.4.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/pubkey"
             }
+        },
+        "node_modules/broadcast-channel/node_modules/@babel/runtime": {
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+            "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.11"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/broadcast-channel/node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
         },
         "node_modules/browser-process-hrtime": {
             "version": "1.0.0",
@@ -14035,6 +14056,7 @@
         },
         "node_modules/detect-node": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dezalgo": {
@@ -15258,7 +15280,8 @@
         },
         "node_modules/for-each": {
             "version": "0.3.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "dependencies": {
                 "is-callable": "^1.1.3"
             }
@@ -15731,7 +15754,8 @@
         },
         "node_modules/gopd": {
             "version": "1.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
             "dependencies": {
                 "get-intrinsic": "^1.1.3"
             },
@@ -16385,7 +16409,8 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -16476,7 +16501,8 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -16609,7 +16635,8 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.10",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
@@ -20171,7 +20198,8 @@
         },
         "node_modules/oblivious-set": {
             "version": "1.1.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
+            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
         },
         "node_modules/obuf": {
             "version": "1.1.2",
@@ -22133,6 +22161,7 @@
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.9",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/regenerator-transform": {
@@ -24101,11 +24130,11 @@
             }
         },
         "node_modules/unload": {
-            "version": "2.3.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "detect-node": "2.1.0"
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/unload/-/unload-2.4.1.tgz",
+            "integrity": "sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw==",
+            "funding": {
+                "url": "https://github.com/sponsors/pubkey"
             }
         },
         "node_modules/unpipe": {
@@ -24168,7 +24197,8 @@
         },
         "node_modules/util": {
             "version": "0.12.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
@@ -24634,7 +24664,8 @@
         },
         "node_modules/which-typed-array": {
             "version": "1.1.9",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
@@ -25064,11 +25095,8 @@
             "name": "@mobilejazz/harmony-bugfender",
             "version": "0.12.0",
             "license": "Apache-2.0",
-            "devDependencies": {
-                "@bugfender/common": "^1.1.1"
-            },
             "peerDependencies": {
-                "@bugfender/sdk": "^2.2.0",
+                "@bugfender/sdk": "^2.2.1",
                 "@mobilejazz/harmony-core": "*"
             }
         },
@@ -25085,11 +25113,6 @@
             "peerDependencies": {
                 "class-transformer": ">=0.2.0"
             }
-        },
-        "packages/core/node_modules/class-transformer": {
-            "version": "0.4.0",
-            "license": "MIT",
-            "peer": true
         },
         "packages/nest": {
             "name": "@mobilejazz/harmony-nest",
@@ -28561,6 +28584,7 @@
         },
         "@babel/runtime": {
             "version": "7.16.7",
+            "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
@@ -28624,20 +28648,24 @@
             "dev": true
         },
         "@bugfender/common": {
-            "version": "1.1.1",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@bugfender/common/-/common-1.1.2.tgz",
+            "integrity": "sha512-mI3iSckPz5LIMelZVJ2AtvuNXqCoX4HUwo//Qu3UPRdFiJVOh34L32rNCZOq3eqEB2f4+k1aODkDbTo3PPWQ3g==",
             "requires": {
                 "util": "^0.12.5"
             }
         },
         "@bugfender/sdk": {
-            "version": "2.2.0",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@bugfender/sdk/-/sdk-2.2.2.tgz",
+            "integrity": "sha512-ZBjMElhth5hhzKqhrqRs0ahVMzhFgol2VxwOcFweYYn26QiGTeRl9sunwSVn0rGpgBKQxKLRHDIa9TXDlDeH4g==",
             "requires": {
-                "@bugfender/common": "^1.1.0",
+                "@bugfender/common": "^1.1.2",
                 "base-58": "0.0.1",
                 "bowser": "^2.11.0",
-                "broadcast-channel": "^4.18.1",
+                "broadcast-channel": "^4.19.1",
                 "error-stack-parser": "^2.1.4",
-                "idb": "^7.1.0",
+                "idb": "^7.1.1",
                 "js-sha256": "^0.9.0",
                 "stack-generator": "^2.0.10"
             }
@@ -31005,21 +31033,13 @@
         },
         "@mobilejazz/harmony-bugfender": {
             "version": "file:packages/bugfender",
-            "requires": {
-                "@bugfender/common": "^1.1.1"
-            }
+            "requires": {}
         },
         "@mobilejazz/harmony-core": {
             "version": "file:packages/core",
             "requires": {
                 "@types/mysql": "^2.15.21",
                 "mysql": "2.x"
-            },
-            "dependencies": {
-                "class-transformer": {
-                    "version": "0.4.0",
-                    "peer": true
-                }
             }
         },
         "@mobilejazz/harmony-nest": {
@@ -32894,7 +32914,9 @@
             }
         },
         "available-typed-arrays": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
         },
         "babel-jest": {
             "version": "28.1.3",
@@ -33210,13 +33232,30 @@
             }
         },
         "broadcast-channel": {
-            "version": "4.18.1",
+            "version": "4.20.2",
+            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.20.2.tgz",
+            "integrity": "sha512-v0lJgMzC+MX4e2KCFWYXChZ2mKTqm5mnJGId6tqJp3NfylggbNd8c2uKeP4MQxD2ucKOesY68aN98zwl9d6Tvg==",
             "requires": {
-                "@babel/runtime": "^7.16.0",
+                "@babel/runtime": "7.20.7",
                 "oblivious-set": "1.1.1",
                 "p-queue": "6.6.2",
                 "rimraf": "3.0.2",
-                "unload": "2.3.1"
+                "unload": "2.4.1"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.20.7",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+                    "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.11"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.11",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+                    "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+                }
             }
         },
         "browser-process-hrtime": {
@@ -34152,7 +34191,8 @@
             "dev": true
         },
         "detect-node": {
-            "version": "2.1.0"
+            "version": "2.1.0",
+            "dev": true
         },
         "dezalgo": {
             "version": "1.0.4",
@@ -34932,6 +34972,8 @@
         },
         "for-each": {
             "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "requires": {
                 "is-callable": "^1.1.3"
             }
@@ -35239,6 +35281,8 @@
         },
         "gopd": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
             "requires": {
                 "get-intrinsic": "^1.1.3"
             }
@@ -36012,7 +36056,9 @@
             }
         },
         "is-callable": {
-            "version": "1.2.7"
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
         },
         "is-ci": {
             "version": "2.0.0",
@@ -36060,6 +36106,8 @@
         },
         "is-generator-function": {
             "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
@@ -36133,6 +36181,8 @@
         },
         "is-typed-array": {
             "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
             "requires": {
                 "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
@@ -38588,7 +38638,9 @@
             }
         },
         "oblivious-set": {
-            "version": "1.1.1"
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
+            "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
         },
         "obuf": {
             "version": "1.1.2",
@@ -39765,7 +39817,8 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.13.9"
+            "version": "0.13.9",
+            "dev": true
         },
         "regenerator-transform": {
             "version": "0.15.0",
@@ -40932,11 +40985,9 @@
             "dev": true
         },
         "unload": {
-            "version": "2.3.1",
-            "requires": {
-                "@babel/runtime": "^7.6.2",
-                "detect-node": "2.1.0"
-            }
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/unload/-/unload-2.4.1.tgz",
+            "integrity": "sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw=="
         },
         "unpipe": {
             "version": "1.0.0"
@@ -40970,6 +41021,8 @@
         },
         "util": {
             "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "requires": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
@@ -41264,6 +41317,8 @@
         },
         "which-typed-array": {
             "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
             "requires": {
                 "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",

--- a/packages/bugfender/package.json
+++ b/packages/bugfender/package.json
@@ -19,11 +19,8 @@
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
         "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
     },
-    "devDependencies": {
-        "@bugfender/common": "^1.1.1"
-    },
     "peerDependencies": {
-        "@bugfender/sdk": "^2.2.0",
+        "@bugfender/sdk": "^2.2.1",
         "@mobilejazz/harmony-core": "*"
     }
 }

--- a/packages/bugfender/src/bugfender.logger.ts
+++ b/packages/bugfender/src/bugfender.logger.ts
@@ -1,6 +1,5 @@
 import { Logger, LogLevel } from '@mobilejazz/harmony-core';
-import { BugfenderClass, LogLevel as BFLogLevel } from '@bugfender/sdk';
-import type { DeviceKeyValue } from '@bugfender/common';
+import { BugfenderClass, DeviceKeyValue, LogLevel as BFLogLevel } from '@bugfender/sdk';
 
 export class BugfenderLogger extends Logger {
     private tag?: string;


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203409192207941/f**

- Remove `@bugfender/common` from `@mobilejazz/harmony-bugfender`. This package is for internal use by Bugfender SDKs; users shouldn't be using it. In some project this forced us to install `@bugfender/common`.
- Instead, use the re-exported types from `@bugfender/sdk`.