### PR TITLE
FRONTEND-8163 :: Bug :: Fix invalid `main` field error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 lerna-debug.log
 npm-debug.log
 examples/backend/volumes
+packages/*/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   all: FRONTEND-8163 :: Bug :: Remove `main` field from `package.json` ([#136])
+-   all: FRONTEND-8163 :: Bug :: Fix invalid `main` field error ([#136])
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   …
+-   all: FRONTEND-8163 :: Bug :: Remove `main` field from `package.json` ([#136])
 
 ### Security
 
 -   …
+
+[#136]: https://github.com/mobilejazz/harmony-typescript/pull/136
 
 ## [0.12.0] - 2023-01-19
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "format": "prettier --write .",
         "validate": "npm run lint && npm test",
         "prepublish": "npm run build",
-        "publish": "lerna publish --contents dist --force-publish --no-private",
+        "publish": "lerna publish --force-publish --no-private",
         "test": "jest --silent",
         "test:watch": "jest --watch",
         "prepare": "husky install",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,6 +7,7 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/typeorm#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
+    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,7 +7,6 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/typeorm#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,8 +7,9 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/typeorm#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
+    "main": "dist/index.js",
+    "files": ["dist"],
     "publishConfig": {
         "access": "public"
     },
@@ -17,7 +18,7 @@
         "build": "tsc",
         "watch": "tsc --watch",
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
-        "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
+        "prepack": "cp ../../README.md ./"
     },
     "peerDependencies": {
         "@angular/common": ">=12",

--- a/packages/bugfender/package.json
+++ b/packages/bugfender/package.json
@@ -7,7 +7,6 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/bugfender#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/bugfender/package.json
+++ b/packages/bugfender/package.json
@@ -7,6 +7,7 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/bugfender#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
+    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/bugfender/package.json
+++ b/packages/bugfender/package.json
@@ -7,8 +7,9 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/bugfender#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
+    "main": "dist/index.js",
+    "files": ["dist"],
     "publishConfig": {
         "access": "public"
     },
@@ -17,7 +18,7 @@
         "build": "tsc",
         "watch": "tsc --watch",
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
-        "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
+        "prepack": "cp ../../README.md ./"
     },
     "devDependencies": {
         "@bugfender/common": "^1.1.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,6 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/core#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/core#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
+    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,8 +7,9 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/core#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
+    "main": "dist/index.js",
+    "files": ["dist"],
     "publishConfig": {
         "access": "public"
     },
@@ -17,7 +18,7 @@
         "build": "tsc",
         "watch": "tsc --watch",
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
-        "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
+        "prepack": "cp ../../README.md ./"
     },
     "devDependencies": {
         "@types/mysql": "^2.15.21"

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -7,8 +7,9 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/nest#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
+    "main": "dist/index.js",
+    "files": ["dist"],
     "publishConfig": {
         "access": "public"
     },
@@ -17,7 +18,7 @@
         "build": "tsc",
         "watch": "tsc --watch",
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
-        "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
+        "prepack": "cp ../../README.md ./"
     },
     "dependencies": {
         "bcryptjs": "~2.4.3",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -7,7 +7,6 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/nest#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -7,6 +7,7 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/nest#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
+    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -7,8 +7,9 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/typeorm#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
+    "main": "dist/index.js",
+    "files": ["dist"],
     "publishConfig": {
         "access": "public"
     },
@@ -17,7 +18,7 @@
         "build": "tsc",
         "watch": "tsc --watch",
         "lint": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore '**/*.ts'",
-        "prepublishOnly": "cp ./package.json ./dist && cp ../../README.md ./dist"
+        "prepack": "cp ../../README.md ./"
     },
     "peerDependencies": {
         "@mobilejazz/harmony-core": "*",

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -7,6 +7,7 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/typeorm#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
+    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -7,7 +7,6 @@
     "repository": "github:mobilejazz/harmony-typescript",
     "homepage": "https://github.com/mobilejazz/harmony-typescript/tree/master/packages/typeorm#readme",
     "bugs": "https://github.com/mobilejazz/harmony-typescript/issues",
-    "main": "dist/index.js",
     "gitHead": "e2cfa71514880a00232939cac36ae4f6c2bc60d9",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
**Asana: https://app.asana.com/0/1109863238977521/1203624980108163/f**

- Remove `--contents dist` flag on root `publish` npm task
- Instead, set `files` property in packages (this limits what gets copied to the published pack)
- Copy README to package root, instead of `dist` folder